### PR TITLE
Apply gofumpt formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ wolphin.session.sql
 
 # Mac cruft
 .DS_Store
+

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,7 +81,7 @@ linters:
 
     # Check for misspellings
     # TODO - enable
-    # - misspell
+    - misspell
 
     # Finds naked/bare returns
     - nakedret

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,10 +59,9 @@ linters:
     # - godot
 
     # Make sure everything's auto-formatted
-    # TODO - enable
-    # - gofmt
-    # - gofumpt
-    # - goimports
+    - gofmt
+    - gofumpt
+    - goimports
 
     # Handle replace, retract, exclude directives in go.mod 
     - gomoddirectives
@@ -158,7 +157,7 @@ linters:
 
     # Detect the possibility to use variables/constants from stdlib.
     # TODO - enable
-    # - usestdlibvars
+    - usestdlibvars
 
     # Finds wasted assignment statements.
     - wastedassign

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -145,8 +145,7 @@ linters:
     - tparallel
 
     # Remove unnecessary type conversions, make code cleaner
-    # TODO - enable
-    # - unconvert
+    - unconvert
 
     # Might be noisy but better to know what is unused
     # TODO - enable

--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -6,7 +6,7 @@ import (
 )
 
 func main() {
-	// TODO - benchmark if it'd be better if these channels were buffered. They will block until a reciever frees up.
+	// TODO - benchmark if it'd be better if these channels were buffered. They will block until a receiver frees up.
 	jobs := make(chan jobstore.Job)
 	status := make(chan jobstore.Job)
 	js := jobstore.NewJobStore()

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -27,7 +27,7 @@ func TestJobsEndpoint(t *testing.T) {
 
 		// Setup
 		w := httptest.NewRecorder()
-		var jsonStr = []byte(`{"docid": "myid1"}`)
+		jsonStr := []byte(`{"docid": "myid1"}`)
 
 		// Test
 		req, _ := http.NewRequest(http.MethodPost, "/jobs/", bytes.NewBuffer(jsonStr))
@@ -43,7 +43,7 @@ func TestJobsEndpoint(t *testing.T) {
 		// Setup
 		// TODO - is there a better way to insert state?
 		w := httptest.NewRecorder()
-		var jsonStr = []byte(`{"docid": "myid1"}`)
+		jsonStr := []byte(`{"docid": "myid1"}`)
 		req, _ := http.NewRequest(http.MethodPost, "/jobs/", bytes.NewBuffer(jsonStr))
 		router.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
@@ -63,14 +63,14 @@ func TestJobsIDEndpoint(t *testing.T) {
 
 	// Setup
 	w := httptest.NewRecorder()
-	var jsonStr = []byte(`{"docid": "myid1"}`)
-	req, _ := http.NewRequest("POST", "/jobs/", bytes.NewBuffer(jsonStr))
+	jsonStr := []byte(`{"docid": "myid1"}`)
+	req, _ := http.NewRequest(http.MethodPost, "/jobs/", bytes.NewBuffer(jsonStr))
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	// Test
 	w = httptest.NewRecorder()
-	req, _ = http.NewRequest("GET", "/jobs/0", nil)
+	req, _ = http.NewRequest(http.MethodGet, "/jobs/0", nil)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)

--- a/pkg/api/jobserver_test.go
+++ b/pkg/api/jobserver_test.go
@@ -87,7 +87,7 @@ func Test_jobServer_createJobHandler(t *testing.T) {
 	t.Run("Test a bad job submission", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
-		var jsonStr = []byte(`{"random": "json"}`)
+		jsonStr := []byte(`{"random": "json"}`)
 		c.Request, _ = http.NewRequest(http.MethodPost, "/jobs/", bytes.NewBuffer(jsonStr))
 
 		js := NewJobServer(nil)

--- a/pkg/api/jobstore/jobstore_test.go
+++ b/pkg/api/jobstore/jobstore_test.go
@@ -100,7 +100,6 @@ func TestJobStore_CreateJob(t *testing.T) {
 		wg.Wait()
 
 		assert.Equal(t, wantedCount, len(js.jobs))
-
 	})
 	// TODO - what happens if we get the same docID submitted multiple times?
 }
@@ -315,7 +314,5 @@ func TestJobStore_updateJobStatus(t *testing.T) {
 		if err.Error() != want {
 			t.Errorf("JobStore.updateJobStatus got error '%v', wanted error '%v'", err.Error(), want)
 		}
-
 	})
-
 }

--- a/pkg/builder/TestTwoSampleTTestBuilder_test.go
+++ b/pkg/builder/TestTwoSampleTTestBuilder_test.go
@@ -6,10 +6,12 @@ import (
 	"time"
 )
 
-var gp = GoodnessPolarity(1)
-var minorThreshold = Threshold(0.05)
-var majorThreshold = Threshold(0.01)
-var cellPtr = GetBuilder("TwoSampleTTest")
+var (
+	gp             = GoodnessPolarity(1)
+	minorThreshold = Threshold(0.05)
+	majorThreshold = Threshold(0.01)
+	cellPtr        = GetBuilder("TwoSampleTTest")
+)
 
 // test for zero variance
 func TestTwoSampleTTestBuilder_test_identical(t *testing.T) {
@@ -29,20 +31,20 @@ func TestTwoSampleTTestBuilder_test_identical(t *testing.T) {
 		t.Fatal(fmt.Sprint("TestTwoSampleTTestBuilder_test_identical - SetInputData - error message : ", err))
 	}
 
-	var epoch = time.Now().Unix()
+	epoch := time.Now().Unix()
 	var ctlData PreCalcRecords
 	for i := 0; i < 10; i++ {
-		var rec = PreCalcRecord{
-			Stat: float64(i) * 1.1,
-			Avtime:  int64(i) + epoch,
+		rec := PreCalcRecord{
+			Stat:   float64(i) * 1.1,
+			Avtime: int64(i) + epoch,
 		}
 		ctlData = append(ctlData, rec)
 	}
 	var expData PreCalcRecords
 	for i := 0; i < 10; i++ {
-		var rec = PreCalcRecord{
-			Stat: float64(i) * 1.1,
-			Avtime:  int64(i) + epoch,
+		rec := PreCalcRecord{
+			Stat:   float64(i) * 1.1,
+			Avtime: int64(i) + epoch,
 		}
 		expData = append(expData, rec)
 	}
@@ -64,7 +66,7 @@ func TestTwoSampleTTestBuilder_test_identical(t *testing.T) {
 
 // this test has inputs that should return a value of 2
 func TestTwoSampleTTestBuilder_test_2(t *testing.T) {
-	var cellPtr = NewTwoSampleTTestBuilder()
+	cellPtr := NewTwoSampleTTestBuilder()
 	err := (*cellPtr).SetGoodnessPolarity(gp)
 	if err != nil {
 		t.Fatal(fmt.Sprint("TestTwoSampleTTestBuilder_test_2 - SetGoodnessPolarity - error message : ", err))
@@ -80,20 +82,20 @@ func TestTwoSampleTTestBuilder_test_2(t *testing.T) {
 	if err != nil {
 		t.Fatal(fmt.Sprint("TestTwoSampleTTestBuilder_test_2 - SetInputData - error message : ", err))
 	}
-	var epoch = time.Now().Unix()
+	epoch := time.Now().Unix()
 	var ctlData PreCalcRecords
 	for i := 0; i < 10; i++ {
-		var rec = PreCalcRecord{
-			Stat: float64(i) * 1.01,
-			Avtime:  int64(i) + epoch,
+		rec := PreCalcRecord{
+			Stat:   float64(i) * 1.01,
+			Avtime: int64(i) + epoch,
 		}
 		ctlData = append(ctlData, rec)
 	}
 	var expData PreCalcRecords
 	for i := 0; i < 10; i++ {
-		var rec = PreCalcRecord{
-			Stat: float64(i) * 1.2,
-			Avtime:  int64(i) + epoch,
+		rec := PreCalcRecord{
+			Stat:   float64(i) * 1.2,
+			Avtime: int64(i) + epoch,
 		}
 		expData = append(expData, rec)
 	}
@@ -132,22 +134,22 @@ func TestTwoSampleTTestBuilder_test_1(t *testing.T) {
 	if err != nil {
 		t.Fatal(fmt.Sprint("TestTwoSampleTTestBuilder_test_1 - SetInputData - error message : ", err))
 	}
-	var epoch = time.Now().Unix()
-	var normData = [10]int{86, 74, 79, 94, 73, 92, 66, 77, 74, 78}
+	epoch := time.Now().Unix()
+	normData := [10]int{86, 74, 79, 94, 73, 92, 66, 77, 74, 78}
 	var ctlData PreCalcRecords
 	for i := 0; i < 10; i++ {
-		var rec = PreCalcRecord{
-			Stat: float64(normData[i]),
-			Avtime:  int64(i) + epoch,
+		rec := PreCalcRecord{
+			Stat:   float64(normData[i]),
+			Avtime: int64(i) + epoch,
 		}
 		ctlData = append(ctlData, rec)
 	}
 	// I don't claim to know why but this modification gives a number set that generates a pvalue 0.015523870374046123 which results in value 1
 	var expData PreCalcRecords
 	for i := 0; i < 10; i++ {
-		var rec = PreCalcRecord{
-			Stat: float64(normData[i] * (i % 2)),
-			Avtime:  int64(i) + epoch,
+		rec := PreCalcRecord{
+			Stat:   float64(normData[i] * (i % 2)),
+			Avtime: int64(i) + epoch,
 		}
 		expData = append(expData, rec)
 	}
@@ -187,13 +189,13 @@ func TestTwoSampleTTestBuilder_test_0(t *testing.T) {
 		t.Fatal(fmt.Sprint("TestTwoSampleTTestBuilder_test_0 - SetInputData - error message : ", err))
 	}
 
-	var epoch = time.Now().Unix()
-	var normData = [10]int{86, 74, 79, 94, 73, 92, 66, 77, 74, 78}
+	epoch := time.Now().Unix()
+	normData := [10]int{86, 74, 79, 94, 73, 92, 66, 77, 74, 78}
 	var ctlData PreCalcRecords
 	for i := 0; i < 10; i++ {
-		var rec = PreCalcRecord{
-			Stat: float64(normData[i]),
-			Avtime:  int64(i) + epoch,
+		rec := PreCalcRecord{
+			Stat:   float64(normData[i]),
+			Avtime: int64(i) + epoch,
 		}
 		ctlData = append(ctlData, rec)
 	}
@@ -201,9 +203,9 @@ func TestTwoSampleTTestBuilder_test_0(t *testing.T) {
 	var expData PreCalcRecords
 	normData = [10]int{87, 74, 79, 94, 73, 92, 66, 77, 74, 78}
 	for i := 0; i < 10; i++ {
-		var rec = PreCalcRecord{
-			Stat: float64(normData[i]),
-			Avtime:  int64(i) + epoch,
+		rec := PreCalcRecord{
+			Stat:   float64(normData[i]),
+			Avtime: int64(i) + epoch,
 		}
 		expData = append(expData, rec)
 	}
@@ -242,20 +244,20 @@ func TestTwoSampleTTestBuilder_different_lengths(t *testing.T) {
 		t.Fatal(fmt.Sprint("SampleTTestBuilder_diff - SetInputData - error message : ", err))
 	}
 
-	var epoch = time.Now().Unix()
+	epoch := time.Now().Unix()
 	var ctlData PreCalcRecords
 	for i := 0; i < 10; i++ {
-		var rec = PreCalcRecord{
-			Stat: float64(i) * 1.01,
-			Avtime:  int64(i) + epoch,
+		rec := PreCalcRecord{
+			Stat:   float64(i) * 1.01,
+			Avtime: int64(i) + epoch,
 		}
 		ctlData = append(ctlData, rec)
 	}
 	var expData PreCalcRecords
 	for i := 0; i < 9; i++ {
-		var rec = PreCalcRecord{
-			Stat: float64(i) * 1.2,
-			Avtime:  int64(i) + epoch,
+		rec := PreCalcRecord{
+			Stat:   float64(i) * 1.2,
+			Avtime: int64(i) + epoch,
 		}
 		expData = append(expData, rec)
 	}
@@ -290,26 +292,26 @@ func TestTwoSampleTTestBuilder_test__match_ctl_short_1(t *testing.T) {
 	if err != nil {
 		t.Fatal(fmt.Sprint("TestTwoSampleTTestBuilder_test_1 - SetInputData - error message : ", err))
 	}
-	var epoch = time.Now().Unix()
-	var normData = [10]int{86, 74, 79, 94, 73, 92, 66, 77, 74, 78}
+	epoch := time.Now().Unix()
+	normData := [10]int{86, 74, 79, 94, 73, 92, 66, 77, 74, 78}
 	var ctlData PreCalcRecords
 	for i := 0; i < 10; i++ {
 		// skip number 5
 		if i == 5 {
 			continue
 		}
-		var rec = PreCalcRecord{
-			Stat: float64(normData[i]),
-			Avtime:  int64(i) + epoch,
+		rec := PreCalcRecord{
+			Stat:   float64(normData[i]),
+			Avtime: int64(i) + epoch,
 		}
 		ctlData = append(ctlData, rec)
 	}
 	// I don't claim to know why but this modification gives a number set that generates a pvalue 0.015523870374046123 which results in value 1
 	var expData PreCalcRecords
 	for i := 0; i < 10; i++ {
-		var rec = PreCalcRecord{
-			Stat: float64(normData[i] * (i % 2)),
-			Avtime:  int64(i) + epoch,
+		rec := PreCalcRecord{
+			Stat:   float64(normData[i] * (i % 2)),
+			Avtime: int64(i) + epoch,
 		}
 		expData = append(expData, rec)
 	}
@@ -348,13 +350,13 @@ func TestTwoSampleTTestBuilder_test__match_exp_short_1(t *testing.T) {
 	if err != nil {
 		t.Fatal(fmt.Sprint("TestTwoSampleTTestBuilder_test_1 - SetInputData - error message : ", err))
 	}
-	var epoch = time.Now().Unix()
-	var normData = [10]int{86, 74, 79, 94, 73, 92, 66, 77, 74, 78}
+	epoch := time.Now().Unix()
+	normData := [10]int{86, 74, 79, 94, 73, 92, 66, 77, 74, 78}
 	var ctlData PreCalcRecords
 	for i := 0; i < 10; i++ {
-		var rec = PreCalcRecord{
-			Stat: float64(normData[i]),
-			Avtime:  int64(i) + epoch,
+		rec := PreCalcRecord{
+			Stat:   float64(normData[i]),
+			Avtime: int64(i) + epoch,
 		}
 		ctlData = append(ctlData, rec)
 	}
@@ -365,9 +367,9 @@ func TestTwoSampleTTestBuilder_test__match_exp_short_1(t *testing.T) {
 		if i == 5 {
 			continue
 		}
-		var rec = PreCalcRecord{
-			Stat: float64(normData[i] * (i % 2)),
-			Avtime:  int64(i) + epoch,
+		rec := PreCalcRecord{
+			Stat:   float64(normData[i] * (i % 2)),
+			Avtime: int64(i) + epoch,
 		}
 		expData = append(expData, rec)
 	}

--- a/pkg/builder/TwoSampleTTestBuilder.go
+++ b/pkg/builder/TwoSampleTTestBuilder.go
@@ -32,11 +32,12 @@ will cause a return of 0.
 */
 import (
 	"fmt"
-	"github.com/aclements/go-moremath/stats"
-	"github.com/go-playground/validator/v10"
 	"log"
 	"reflect"
 	"strings"
+
+	"github.com/aclements/go-moremath/stats"
+	"github.com/go-playground/validator/v10"
 )
 
 // use a single instance of Validate, it caches struct info
@@ -114,7 +115,7 @@ func (scc *ScorecardCell) deriveCTCInputData(queryResult BuilderCTCResult, stati
 		record = queryResult.CtlData[i]
 		stat, err = CalculateStatCTC(record.Hit, record.Fa, record.Miss, record.Cn, statisticType)
 		if err == nil {
-			//include this one
+			// include this one
 			ctlData = append(ctlData, PreCalcRecord{Stat: float64(stat), Avtime: record.Avtime})
 		}
 	}
@@ -122,7 +123,7 @@ func (scc *ScorecardCell) deriveCTCInputData(queryResult BuilderCTCResult, stati
 		record = queryResult.ExpData[i]
 		stat, err = CalculateStatCTC(record.Hit, record.Fa, record.Miss, record.Cn, statisticType)
 		if err == nil {
-			//include this one
+			// include this one
 			expData = append(expData, PreCalcRecord{Stat: float64(stat), Avtime: record.Avtime})
 		}
 	}
@@ -142,14 +143,14 @@ func (scc *ScorecardCell) deriveScalarInputData(queryResult BuilderScalarResult,
 	for _, record = range queryResult.CtlData {
 		stat, err = CalculateStatScalar(record.SquareDiffSum, record.NSum, record.ObsModelDiffSum, record.ModelSum, record.ObsSum, record.AbsSum, statisticType)
 		if err == nil {
-			//include this one
+			// include this one
 			ctlData = append(ctlData, PreCalcRecord{Stat: float64(stat), Avtime: record.Avtime})
 		}
 	}
 	for _, record = range queryResult.CtlData {
 		stat, err = CalculateStatScalar(record.SquareDiffSum, record.NSum, record.ObsModelDiffSum, record.ModelSum, record.ObsSum, record.AbsSum, statisticType)
 		if err == nil {
-			//include this one
+			// include this one
 			expData = append(expData, PreCalcRecord{Stat: float64(stat), Avtime: record.Avtime})
 		}
 	}
@@ -252,7 +253,7 @@ func (scc *ScorecardCell) ComputeSignificance() error {
 		v, err = scc.deriveValue(difference, ret.P)
 		if err != nil {
 			log.Print(err)
-			//scc.Value = &v
+			// scc.Value = &v
 			return fmt.Errorf("TwoSampleTTestBuilder ComputeSignificance - deriveValue error:  %q", err)
 		}
 		scc.ValuePtr = &v
@@ -323,7 +324,7 @@ func getGoodnessPolarity(statisticType string) (polarity GoodnessPolarity, err e
 }
 
 func (scc *ScorecardCell) Build(qrPtr interface{}, statisticType string, minorThreshold float64, majorThreshold float64) (value int, err error) {
-	//DerivePreCalcInputData(ctlQR PreCalcRecords, expQR PreCalcRecords, statisticType string)
+	// DerivePreCalcInputData(ctlQR PreCalcRecords, expQR PreCalcRecords, statisticType string)
 	// build the input data elements and
 	// for all the input elements fire off a thread to do the compute
 

--- a/pkg/builder/TwoSampleTTestBuilder.go
+++ b/pkg/builder/TwoSampleTTestBuilder.go
@@ -12,7 +12,7 @@ two-tailed test.
 For reference about Hypothesis testing with P-value look here...
 https://refactoring.guru/design-patterns/builder/go/example
 
-For these analysis we asume for the null hypothesis that the statistic
+For these analysis we assume for the null hypothesis that the statistic
 that is generated from the "validation data source", which might be thought of as the
 control source population, is the same as the "data source", which might be thought
 of as the experimental source population.
@@ -202,7 +202,7 @@ func (scc *ScorecardCell) DeriveInputData(qrPtr interface{}, statisticType strin
 }
 
 func (scc *ScorecardCell) ComputeSignificance() error {
-	// scc should hvae already been populated
+	// scc should have already been populated
 	if scc.Data.CtlPop == nil || scc.Data.ExpPop == nil {
 		return fmt.Errorf("TwoSampleTTestBuilder ComputeSignificance - no data")
 	}
@@ -229,7 +229,7 @@ func (scc *ScorecardCell) ComputeSignificance() error {
 	ret, err := stats.PairedTTest(derivedData.CtlPop, derivedData.ExpPop, μ0, alt)
 	if err != nil {
 		if strings.Contains(fmt.Sprint(err), "zero variance") {
-			// we are not considering indentical sets to be errors
+			// we are not considering identical sets to be errors
 			// set pval to 1 and value to 0
 			scc.Pvalue = 1
 			var v int = 0

--- a/pkg/builder/TwoSampleTTestBuilder.go
+++ b/pkg/builder/TwoSampleTTestBuilder.go
@@ -144,14 +144,14 @@ func (scc *ScorecardCell) deriveScalarInputData(queryResult BuilderScalarResult,
 		stat, err = CalculateStatScalar(record.SquareDiffSum, record.NSum, record.ObsModelDiffSum, record.ModelSum, record.ObsSum, record.AbsSum, statisticType)
 		if err == nil {
 			// include this one
-			ctlData = append(ctlData, PreCalcRecord{Stat: float64(stat), Avtime: record.Avtime})
+			ctlData = append(ctlData, PreCalcRecord{Stat: stat, Avtime: record.Avtime})
 		}
 	}
 	for _, record = range queryResult.CtlData {
 		stat, err = CalculateStatScalar(record.SquareDiffSum, record.NSum, record.ObsModelDiffSum, record.ModelSum, record.ObsSum, record.AbsSum, statisticType)
 		if err == nil {
 			// include this one
-			expData = append(expData, PreCalcRecord{Stat: float64(stat), Avtime: record.Avtime})
+			expData = append(expData, PreCalcRecord{Stat: stat, Avtime: record.Avtime})
 		}
 	}
 	// return the unmatched Scalar dataSet

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1,5 +1,0 @@
-package builder
-
-func TestString() string {
-	return "this is a string from builder"
-}

--- a/pkg/builder/builder_stats.go
+++ b/pkg/builder/builder_stats.go
@@ -2,10 +2,10 @@ package builder
 
 import (
 	"fmt"
-	"github.com/go-playground/validator/v10"
 	"math"
-)
 
+	"github.com/go-playground/validator/v10"
+)
 
 type DataSet struct {
 	ctlPop []PreCalcRecord
@@ -46,15 +46,15 @@ func CalculateStatCTC(hit float32, fa float32, miss float32, cn float32, statist
 	}
 
 	switch statistic {
-	case "TSS (True Skill Score)": //radar
+	case "TSS (True Skill Score)": // radar
 		value = ((hit*cn - fa*miss) / ((hit + miss) * (fa + cn))) * 100
 	// some PODy measures look for a value over a threshold, some look for under
-	case "PODy (POD of value < threshold)": //ceiling
+	case "PODy (POD of value < threshold)": // ceiling
 		value = hit / (hit + miss) * 100
-	case "PODy (POD of value > threshold)": //radar
+	case "PODy (POD of value > threshold)": // radar
 		value = hit / (hit + miss) * 100
 	// some PODn measures look for a value under a threshold, some look for over
-	case "PODn (POD of value > threshold)": //ceiling
+	case "PODn (POD of value > threshold)": // ceiling
 		value = cn / (cn + fa) * 100
 	case "PODn (POD of value < threshold)": // radar
 		value = cn / (cn + fa) * 100
@@ -84,11 +84,11 @@ func CalculateStatScalar(squareDiffSum, NSum, obsModelDiffSum, modelSum, obsSum,
 	var err error
 	var value float64
 	switch statistic {
-	case "RMSE": //surface
+	case "RMSE": // surface
 		value = math.Sqrt(squareDiffSum / NSum)
-	case "Bias (Model - Obs)": //surface
+	case "Bias (Model - Obs)": // surface
 		value = (modelSum - obsSum) / NSum
-	case "MAE (temp and dewpoint only)": //surface
+	case "MAE (temp and dewpoint only)": // surface
 		value = absSum / NSum
 	case "MAE": // landuse
 		value = absSum / NSum
@@ -105,8 +105,8 @@ func GetMatchedDataSet(dataSet DataSet) (DataSet, error) {
 	var result DataSet
 	var indexCtl int = 0
 	var indexExp int = 0
-	var lenCtl = len(dataSet.ctlPop)
-	var lenExp = len(dataSet.expPop)
+	lenCtl := len(dataSet.ctlPop)
+	lenExp := len(dataSet.expPop)
 	var err error = nil
 	defer func() {
 		if r := recover(); r != nil {
@@ -114,7 +114,7 @@ func GetMatchedDataSet(dataSet DataSet) (DataSet, error) {
 		}
 	}()
 	if lenCtl == 0 || lenExp == 0 {
-		return DataSet{ctlPop:[]PreCalcRecord{},expPop: []PreCalcRecord{}}, nil
+		return DataSet{ctlPop: []PreCalcRecord{}, expPop: []PreCalcRecord{}}, nil
 	}
 	for {
 		if dataSet.ctlPop[indexCtl].Avtime == dataSet.expPop[indexExp].Avtime {

--- a/pkg/builder/builder_stats_test.go
+++ b/pkg/builder/builder_stats_test.go
@@ -1,32 +1,34 @@
 package builder
 
 import (
-	"github.com/stretchr/testify/assert"
+	"math"
 	"reflect"
 	"testing"
 	"time"
-	"math"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func getDataSet(epoch int64, ctlValues []float64, expValues []float64) DataSet {
-	var ctlLen = len(ctlValues)
-	var expLen = len(expValues)
-	var tmpc = make([]PreCalcRecord, ctlLen)
-	var tmpe = make([]PreCalcRecord, expLen)
+	ctlLen := len(ctlValues)
+	expLen := len(expValues)
+	tmpc := make([]PreCalcRecord, ctlLen)
+	tmpe := make([]PreCalcRecord, expLen)
 	for i := 0; i < ctlLen; i++ {
 		tmpc[i] = PreCalcRecord{Avtime: epoch + int64(ctlValues[i]), Stat: ctlValues[i]}
 	}
 	for i := 0; i < expLen; i++ {
 		tmpe[i] = PreCalcRecord{Avtime: epoch + int64(expValues[i]), Stat: expValues[i]}
 	}
-	var dataSet = DataSet{
+	dataSet := DataSet{
 		ctlPop: tmpc,
 		expPop: tmpe,
 	}
 	return dataSet
 }
+
 func TestGetMatchedDataSet(t *testing.T) {
-	var epoch = time.Now().Unix()
+	epoch := time.Now().Unix()
 	tests := []struct {
 		name    string
 		args    DataSet
@@ -106,7 +108,6 @@ func TestGetMatchedDataSet(t *testing.T) {
 }
 
 func Test_calculateStatScalar(t *testing.T) {
-
 	/*
 	   Statistics for scalar
 	   "RMSE" - surface
@@ -132,15 +133,15 @@ func Test_calculateStatScalar(t *testing.T) {
 		statistic       string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    float64
+		name      string
+		args      args
+		want      float64
 		tolerance float64
-		wantErr bool
+		wantErr   bool
 	}{
-		//test cases.
+		// test cases.
 		{
-			//RMSE.sql
+			// RMSE.sql
 			name: "RMSE",
 			args: args{
 				squareDiffSum:   22019.0390625,
@@ -151,12 +152,12 @@ func Test_calculateStatScalar(t *testing.T) {
 				absSum:          4889.7998046875,
 				statistic:       "RMSE",
 			},
-			want:    1.957 * 1.8,
+			want:      1.957 * 1.8,
 			tolerance: 0.005,
-			wantErr: false,
+			wantErr:   false,
 		},
 		{
-			//BIAS_MODEL_OBS.sql
+			// BIAS_MODEL_OBS.sql
 			name: "Bias (Model - Obs)",
 			args: args{
 				squareDiffSum:   22019.0390625,
@@ -167,9 +168,9 @@ func Test_calculateStatScalar(t *testing.T) {
 				absSum:          4889.7998046875,
 				statistic:       "Bias (Model - Obs)",
 			},
-			want:    -0.5741 * 1.8,
+			want:      -0.5741 * 1.8,
 			tolerance: 0.001,
-			wantErr: false,
+			wantErr:   false,
 		},
 		{
 			// MAE_temp_dewpoint.sql
@@ -183,9 +184,9 @@ func Test_calculateStatScalar(t *testing.T) {
 				absSum:          740.9000244140630,
 				statistic:       "MAE (temp and dewpoint only)",
 			},
-			want:    1.942 * 1.8,
+			want:      1.942 * 1.8,
 			tolerance: 0.005,
-			wantErr: false,
+			wantErr:   false,
 		},
 		{
 			// MAE.sql
@@ -199,9 +200,9 @@ func Test_calculateStatScalar(t *testing.T) {
 				absSum:          4.271478652954102,
 				statistic:       "MAE",
 			},
-			want:    0.3286,
+			want:      0.3286,
 			tolerance: 0.005,
-			wantErr: false,
+			wantErr:   false,
 		},
 	}
 	for _, tt := range tests {
@@ -254,7 +255,7 @@ func Test_calculateStatCTC(t *testing.T) {
 		want    float32
 		wantErr bool
 	}{
-		//test cases.
+		// test cases.
 		{
 			// TSS.sql - radar
 			name: "TSS (True Skill Score)",
@@ -269,7 +270,7 @@ func Test_calculateStatCTC(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			//PODy_lt.sql - ceiling
+			// PODy_lt.sql - ceiling
 			name: "PODy (POD of value < threshold)",
 			args: args{
 				hit:       10,
@@ -282,7 +283,7 @@ func Test_calculateStatCTC(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			//PODy_gt.sql - radar
+			// PODy_gt.sql - radar
 			name: "PODy (POD of value > threshold)",
 			args: args{
 				hit:       1583,
@@ -307,7 +308,7 @@ func Test_calculateStatCTC(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			//PODn_lt.sql - radar
+			// PODn_lt.sql - radar
 			name: "PODn (POD of value < threshold)",
 			args: args{
 				hit:       1583,
@@ -320,7 +321,7 @@ func Test_calculateStatCTC(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			//FAR.sql - radar
+			// FAR.sql - radar
 			name: "FAR (False Alarm Ratio)",
 			args: args{
 				hit:       1583,
@@ -333,7 +334,7 @@ func Test_calculateStatCTC(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			//CSI.sql - radar
+			// CSI.sql - radar
 			name: "CSI (Critical Success Index)",
 			args: args{
 				hit:       1583,
@@ -346,7 +347,7 @@ func Test_calculateStatCTC(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			//HSS.sql - radar
+			// HSS.sql - radar
 			name: "HSS (Heidke Skill Score)",
 			args: args{
 				hit:       1583,
@@ -359,7 +360,7 @@ func Test_calculateStatCTC(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			//ETS.sql - radar
+			// ETS.sql - radar
 			name: "ETS (Equitable Threat Score)",
 			args: args{
 				hit:       1583,
@@ -396,7 +397,7 @@ func Test_calculateStatCTC(t *testing.T) {
 				statistic: "TSS (True Skill Score)",
 			},
 			want: 0.0,
-			//wantErr: true,
+			// wantErr: true,
 			wantErr: false,
 		},
 	}

--- a/pkg/builder/iBuilder.go
+++ b/pkg/builder/iBuilder.go
@@ -42,6 +42,7 @@ A ScorecardCellBuilder is an interface that provides several functions:
 */
 
 type StatType string
+
 const ErrorValue = -9999
 
 type DerivedDataElement struct {
@@ -49,29 +50,31 @@ type DerivedDataElement struct {
 	ExpPop []float64
 }
 
-// -1 or 1
-type GoodnessPolarity int
-type Threshold float64
-type ScorecardCell struct {
-	Data             DerivedDataElement
-	goodnessPolarity GoodnessPolarity
-	majorThreshold   Threshold
-	minorThreshold   Threshold
-	Pvalue           float64
-	ValuePtr         *int
-}
+type (
+	GoodnessPolarity int // -1 or 1
+	Threshold        float64
+	ScorecardCell    struct {
+		Data             DerivedDataElement
+		goodnessPolarity GoodnessPolarity
+		majorThreshold   Threshold
+		minorThreshold   Threshold
+		Pvalue           float64
+		ValuePtr         *int
+	}
+)
+
 // these are floats because of the division in the CalculateStatCTC func
 type CTCRecord struct {
 	Avtime int64
-	Hit  float32
-	Miss float32
-	Fa   float32
-	Cn   float32
+	Hit    float32
+	Miss   float32
+	Fa     float32
+	Cn     float32
 }
 type CTCRecords = []CTCRecord
 
 type ScalarRecord struct {
-	Avtime            int64
+	Avtime          int64
 	SquareDiffSum   float64
 	NSum            float64
 	ObsModelDiffSum float64
@@ -82,11 +85,10 @@ type ScalarRecord struct {
 type ScalarRecords []ScalarRecord
 
 type PreCalcRecord struct {
-	Avtime  int64
-	Stat float64
+	Avtime int64
+	Stat   float64
 }
 type PreCalcRecords []PreCalcRecord
-
 
 type BuilderScalarResult struct {
 	CtlData ScalarRecords

--- a/pkg/director/iDirector.go
+++ b/pkg/director/iDirector.go
@@ -42,9 +42,9 @@ type Director struct {
 	db               *sql.DB
 	queryBlock       ScorecardBlock
 	resultBlock      ScorecardBlock
-	dateRange 		DateRange
-	minorThreshold  float64
-	majorThreshold  float64
+	dateRange        DateRange
+	minorThreshold   float64
+	majorThreshold   float64
 }
 
 type DirectorBuilder interface {
@@ -54,12 +54,12 @@ type DirectorBuilder interface {
 
 type DateRange struct {
 	FromSecs int64
-	ToSecs int64
+	ToSecs   int64
 }
 
 func GetDirector(directorType string, mysqlCredentials DbCredentials, dateRange DateRange, minorThreshold float64, majorThreshold float64) (*Director, error) {
 	if directorType == "MysqlDirector" {
-		return  NewMysqlDirector(mysqlCredentials, dateRange, minorThreshold, majorThreshold)
+		return NewMysqlDirector(mysqlCredentials, dateRange, minorThreshold, majorThreshold)
 	} else {
 		return nil, fmt.Errorf("Director GetDirector unsupported directorType: %q", directorType)
 	}

--- a/pkg/director/mysql_director.go
+++ b/pkg/director/mysql_director.go
@@ -25,11 +25,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/NOAA-GSL/vxDataProcessor/pkg/builder"
-	_ "github.com/go-sql-driver/mysql"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/NOAA-GSL/vxDataProcessor/pkg/builder"
+	_ "github.com/go-sql-driver/mysql"
 )
 
 var dateRange DateRange
@@ -44,15 +45,15 @@ func Keys[K comparable, V any](m map[K]V) []K {
 
 func getMySqlConnection(mysqlCredentials DbCredentials) (*sql.DB, error) {
 	// get the connection
-	var driver = "mysql"
+	driver := "mysql"
 	//user:password@tcp(localhost:5555)
-	var dataSource = fmt.Sprintf("%s:%s@tcp(%s)/", mysqlCredentials.User, mysqlCredentials.Password, mysqlCredentials.Host)
+	dataSource := fmt.Sprintf("%s:%s@tcp(%s)/", mysqlCredentials.User, mysqlCredentials.Password, mysqlCredentials.Host)
 	var db *sql.DB
 	db, err := sql.Open(driver, dataSource)
 	if err != nil {
 		return nil, fmt.Errorf("mysql_director getMySqlConnection sql open error %q", err)
 	}
-	var ctx, cancelfunc = context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancelfunc := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelfunc()
 	if err := db.PingContext(ctx); err != nil {
 		return nil, fmt.Errorf("mysql_director Build sql open/ping error: %q", err)
@@ -63,7 +64,7 @@ func getMySqlConnection(mysqlCredentials DbCredentials) (*sql.DB, error) {
 var mysqlDirector = Director{}
 
 func NewMysqlDirector(mysqlCredentials DbCredentials, dateRange DateRange, minorThreshold float64, majorThreshold float64) (*Director, error) {
-	var db, err = getMySqlConnection(mysqlCredentials)
+	db, err := getMySqlConnection(mysqlCredentials)
 	if err != nil {
 		return nil, fmt.Errorf("mysql_director NewMysqlDirector error: %q", err)
 	} else {
@@ -152,9 +153,11 @@ func contains(s []string, e string) bool {
 	return false
 }
 
-var statistics []string
-var statisticType string
-var thisIsALeaf bool
+var (
+	statistics    []string
+	statisticType string
+	thisIsALeaf   bool
+)
 
 // Recursively process a region/Block until all the leaves (which are cells) have been traversed and processed
 func processSub(region interface{}, queryElem interface{}) (interface{}, error) {
@@ -237,7 +240,7 @@ func processSub(region interface{}, queryElem interface{}) (interface{}, error) 
 		// build the input data elements - derive the statistic and summary value
 		// for this element i.e. this cell in the scorecard
 		// The build will fill in the value (write into the result)
-		//Build(qr QueryResult, statisticType string, dataType string
+		// Build(qr QueryResult, statisticType string, dataType string
 		if queryError {
 			log.Printf("mysql_director query error %v", err)
 			return builder.ErrorValue, err
@@ -258,7 +261,7 @@ func processSub(region interface{}, queryElem interface{}) (interface{}, error) 
 			if contains(statistics, elemKey) {
 				statisticType = elemKey
 			}
-			var queryElem = queryElem.(map[string]interface{})[elemKey]
+			queryElem := queryElem.(map[string]interface{})[elemKey]
 			region.(map[string]interface{})[elemKey], err = processSub(region.(map[string]interface{})[elemKey], queryElem)
 			if err != nil {
 				return builder.ErrorValue, err

--- a/pkg/director/mysql_director.go
+++ b/pkg/director/mysql_director.go
@@ -250,7 +250,7 @@ func processSub(region interface{}, queryElem interface{}) (interface{}, error) 
 			if err != nil {
 				return builder.ErrorValue, fmt.Errorf("mysql_director processSub error from builder %q", err)
 			} else {
-				return int(value), nil
+				return value, nil
 			}
 		}
 	} else {

--- a/pkg/director/mysql_director_test.go
+++ b/pkg/director/mysql_director_test.go
@@ -4,18 +4,18 @@
 package director
 
 import (
-	"testing"
 	"fmt"
 	"os"
 	"strings"
+	"testing"
 	"time"
+
 	"github.com/NOAA-GSL/vxDataProcessor/pkg/builder"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/joho/godotenv"
 )
 
 func Test_getMySqlConnection(t *testing.T) {
-
 	type args struct {
 		mysqlCredentials DbCredentials
 	}
@@ -45,9 +45,9 @@ func Test_getMySqlConnection(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "test_connection",
-			args: args{mysqlCredentials: mysqlCredentials},
-			want: "*sql.DB",
+			name:    "test_connection",
+			args:    args{mysqlCredentials: mysqlCredentials},
+			want:    "*sql.DB",
 			wantErr: false,
 		},
 	}
@@ -66,9 +66,8 @@ func Test_getMySqlConnection(t *testing.T) {
 	}
 }
 
-//record.squareDiffSum record.NSum record.obsModelDiffSum record.modelSum record.obsSum record.absSum record.time
+// record.squareDiffSum record.NSum record.obsModelDiffSum record.modelSum record.obsSum record.absSum record.time
 func Test_mySqlQuery(t *testing.T) {
-
 	var environmentFile string = fmt.Sprint(os.Getenv("HOME"), "/vxDataProcessor.env")
 	err := godotenv.Load(environmentFile)
 	if err != nil {
@@ -89,59 +88,59 @@ func Test_mySqlQuery(t *testing.T) {
 		t.Fatalf("Undefined MYSQL_PASSWORD in environment")
 	}
 	mysqlDB, err := getMySqlConnection(mysqlCredentials)
-	if (err != nil){
+	if err != nil {
 		t.Fatalf("getMySqlConnection() error = %v", err)
 		return
 	}
 	defer mysqlDB.Close()
 	tests := []struct {
-		name    string
-		args    string
-		fromEpoch string
-		toEpoch string
-		recordType	 string
-		want    int
-		wantErr bool
+		name       string
+		args       string
+		fromEpoch  string
+		toEpoch    string
+		recordType string
+		want       int
+		wantErr    bool
 	}{
 		{
-			name: "test_query_scalar",
-			args: "testdata/scalar_stmnt.sql",
+			name:       "test_query_scalar",
+			args:       "testdata/scalar_stmnt.sql",
 			recordType: "scalar",
-			fromEpoch: "1675281600",// Tue, 1 Feb 2023 20:00:00 GMT
-			toEpoch: "1677700800",// Tue, 1 Mar 2023 20:00:00 GMT
-			want: 667,
-			wantErr: false,
+			fromEpoch:  "1675281600", // Tue, 1 Feb 2023 20:00:00 GMT
+			toEpoch:    "1677700800", // Tue, 1 Mar 2023 20:00:00 GMT
+			want:       667,
+			wantErr:    false,
 		},
 		{
-			name: "test_query_ctc",
-			args: "testdata/ctc_stmnt.sql",
+			name:       "test_query_ctc",
+			args:       "testdata/ctc_stmnt.sql",
 			recordType: "ctc",
-			fromEpoch: "1675281600",// Tue, 1 Feb 2023 20:00:00 GMT
-			toEpoch: "1677700800",// Tue, 1 Mar 2023 20:00:00 GMT
-			want: 613,
-			wantErr: false,
+			fromEpoch:  "1675281600", // Tue, 1 Feb 2023 20:00:00 GMT
+			toEpoch:    "1677700800", // Tue, 1 Mar 2023 20:00:00 GMT
+			want:       613,
+			wantErr:    false,
 		},
 		{
-			name: "test_query_precalc",
-			args: "testdata/precalc_stmnt.sql",
+			name:       "test_query_precalc",
+			args:       "testdata/precalc_stmnt.sql",
 			recordType: "precalc",
-			fromEpoch: "1587513600", // Wednesday, April 22, 2020 12:00:00 AM
-			toEpoch: "1631620800", // Tuesday, September 14, 2021 12:00:00 PM
-			want: 1000,
-			wantErr: false,
+			fromEpoch:  "1587513600", // Wednesday, April 22, 2020 12:00:00 AM
+			toEpoch:    "1631620800", // Tuesday, September 14, 2021 12:00:00 PM
+			want:       1000,
+			wantErr:    false,
 		},
 	}
 
 	for _, tt := range tests {
 		buf, err := os.ReadFile(tt.args)
-		if (err != nil){
+		if err != nil {
 			t.Fatalf("Test_mySqlQuery() error reading test statement= %v", err)
 			return
 		}
 
 		stmnt := string(buf)
 		fromEpoch := tt.fromEpoch // Tue, 1 Feb 2023 20:00:00 GMT
-		toEpoch := tt.toEpoch  // Tue, 1 Mar 2023 20:00:00 GMT
+		toEpoch := tt.toEpoch     // Tue, 1 Mar 2023 20:00:00 GMT
 		stmnt = strings.ReplaceAll(stmnt, "{ { fromSecs } }", fromEpoch)
 		stmnt = strings.ReplaceAll(stmnt, "{ { toSecs } }", toEpoch)
 		t.Run(tt.name, func(t *testing.T) {
@@ -155,32 +154,32 @@ func Test_mySqlQuery(t *testing.T) {
 			defer rows.Close()
 			for rows.Next() {
 				switch tt.recordType {
-					case "scalar":
-						var record builder.ScalarRecord
-						if err := rows.Scan(&record.Avtime,&record.SquareDiffSum, &record.NSum, &record.ObsModelDiffSum, &record.ModelSum, &record.ObsSum, &record.AbsSum); err != nil {
-							t.Errorf("could not scan row: %v", err)
-						} else {
-							records = append(records, record)
-						}
-					case "ctc":
-						var record builder.CTCRecord
-						if err := rows.Scan(&record.Avtime, &record.Hit, &record.Miss, &record.Fa, &record.Cn); err != nil {
-							t.Errorf("could not scan row: %v", err)
-						}
+				case "scalar":
+					var record builder.ScalarRecord
+					if err := rows.Scan(&record.Avtime, &record.SquareDiffSum, &record.NSum, &record.ObsModelDiffSum, &record.ModelSum, &record.ObsSum, &record.AbsSum); err != nil {
+						t.Errorf("could not scan row: %v", err)
+					} else {
 						records = append(records, record)
-					case "precalc":
-						var record builder.PreCalcRecord
-						if err := rows.Scan(&record.Avtime, &record.Stat); err != nil {
-							t.Errorf("could not scan row: %v", err)
-						}
-						records = append(records, record)
-					default:
-						t.Fatalf("Test_mySqlQuery unrecognized record type %q", tt.recordType)
+					}
+				case "ctc":
+					var record builder.CTCRecord
+					if err := rows.Scan(&record.Avtime, &record.Hit, &record.Miss, &record.Fa, &record.Cn); err != nil {
+						t.Errorf("could not scan row: %v", err)
+					}
+					records = append(records, record)
+				case "precalc":
+					var record builder.PreCalcRecord
+					if err := rows.Scan(&record.Avtime, &record.Stat); err != nil {
+						t.Errorf("could not scan row: %v", err)
+					}
+					records = append(records, record)
+				default:
+					t.Fatalf("Test_mySqlQuery unrecognized record type %q", tt.recordType)
 				}
 			}
 			elapsed := time.Since(start)
 			fmt.Printf("The query and scan took combined %s", elapsed)
-			if tt.want != len(records){
+			if tt.want != len(records) {
 				t.Errorf("Test_mySqlQuery() data length is wrong = %v", len(records))
 			}
 		})

--- a/pkg/manager/iManager.go
+++ b/pkg/manager/iManager.go
@@ -10,7 +10,7 @@ The manager reads the scorecard document and uses
 Directors in go routines to process the region / blocks of the scorecard.
 Each Region within a scorecard Block is passed to a
 Director. Since maps are always passed by reference
-the manager avoids duplicating data. As the Directors and thier
+the manager avoids duplicating data. As the Directors and their
 spawned Builders build the scorecard results the scorecard
 in-memory document will get filled in with results.
 When a director finishes the manager will upsert the document.

--- a/pkg/manager/iManager.go
+++ b/pkg/manager/iManager.go
@@ -19,6 +19,7 @@ processed.
 */
 import (
 	"fmt"
+
 	"github.com/couchbase/gocb/v2"
 )
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -44,16 +44,17 @@ and then it politely dies.
 
 import (
 	"fmt"
-	"github.com/NOAA-GSL/vxDataProcessor/pkg/director"
-	"github.com/couchbase/gocb/v2"
-	"github.com/joho/godotenv"
+	"log"
 	"os"
 	"reflect"
 	"sort"
-	"log"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/NOAA-GSL/vxDataProcessor/pkg/director"
+	"github.com/couchbase/gocb/v2"
+	"github.com/joho/godotenv"
 )
 
 func loadEnvironmant(environmentFile string) (mysqlCredentials, cbCredentials director.DbCredentials, err error) {
@@ -104,7 +105,7 @@ func loadEnvironmant(environmentFile string) (mysqlCredentials, cbCredentials di
 // get the couchbase connection
 // mysql connections are maintained in the mysql_director
 func getConnection(mngr *Manager, cbCredentials director.DbCredentials) (err error) {
-	var options = gocb.ClusterOptions{
+	options := gocb.ClusterOptions{
 		Authenticator: gocb.PasswordAuthenticator{
 			Username: cbCredentials.User,
 			Password: cbCredentials.Password,
@@ -291,7 +292,7 @@ func processRegion(
 	if strings.ToUpper(appName) == "CB" {
 		log.Print("launch CB director - which we don't have yet")
 	} else {
-		//launch mysql director
+		// launch mysql director
 		mysqlDirector, err := director.GetDirector("MysqlDirector", mysqlCredentials, dateRange, minorThreshold, majorThreshold)
 		if err != nil {
 			err = fmt.Errorf("manager Run error getting director: %q", err)
@@ -307,7 +308,7 @@ func processRegion(
 	if err != nil {
 		return fmt.Errorf("manager Run error upserting resultRegion: %q error: %q", blockRegionName, err)
 	}
-	//notify server to update with scorecardApUrl
+	// notify server to update with scorecardApUrl
 	return nil
 }
 

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -8,46 +8,48 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"testing"
 	"sort"
+	"testing"
 	"time"
+
 	"github.com/NOAA-GSL/vxDataProcessor/pkg/director"
 	"github.com/couchbase/gocb/v2"
 )
-func getTestDoc(mngr *Manager) (map[string]interface{}, error){
-		// get the test scorecard document (this is a Result - not a document)
-		var scorecardDataIn *gocb.GetResult
-		scorecardDataIn, err := mngr.cb.Collection.Get("SCTEST:test_scorecard", nil)
-		if err != nil {
-			return nil, fmt.Errorf("mysql_test_director error getting SCTEST:test_scorecard %q", err)
-		}
-		// get the unmarshalled document (the Content) from the result
-		var scorecardCB map[string]interface{}
-		err = scorecardDataIn.Content(&scorecardCB)
-		if err != nil {
-			return nil, fmt.Errorf("mysql_test_director error getting SCTEST:test_scorecard Content %v", err)
-		}
+
+func getTestDoc(mngr *Manager) (map[string]interface{}, error) {
+	// get the test scorecard document (this is a Result - not a document)
+	var scorecardDataIn *gocb.GetResult
+	scorecardDataIn, err := mngr.cb.Collection.Get("SCTEST:test_scorecard", nil)
+	if err != nil {
+		return nil, fmt.Errorf("mysql_test_director error getting SCTEST:test_scorecard %q", err)
+	}
+	// get the unmarshalled document (the Content) from the result
+	var scorecardCB map[string]interface{}
+	err = scorecardDataIn.Content(&scorecardCB)
+	if err != nil {
+		return nil, fmt.Errorf("mysql_test_director error getting SCTEST:test_scorecard Content %v", err)
+	}
 	return scorecardCB, nil
 }
 
 func upsertTestDoc(mngr *Manager) error {
-		// read the test document from the test file
-		testScorcardFile := "./testdata/test_scorecard.json"
-		if _, err := os.Stat(testScorcardFile); err != nil {
-			return fmt.Errorf("upsertTestDoc error reading test scorecard file %v", err)
-		}
-		var scorecardBytes, _ = os.ReadFile(testScorcardFile)
-		var scorecard map[string]interface{}
-		err := json.Unmarshal(scorecardBytes, &scorecard)
-		if err != nil {
-			return fmt.Errorf("upsertTestDoc error unmarshalling test scorecard file %v", err)
-		}
-		// upsert the test scorecard document
-		_, err = mngr.cb.Collection.Upsert("SCTEST:test_scorecard", scorecard, nil)
-		if err != nil {
-			return fmt.Errorf("upsertTestDoc error upserting test scorecard file %v", err)
-		}
-		return nil
+	// read the test document from the test file
+	testScorcardFile := "./testdata/test_scorecard.json"
+	if _, err := os.Stat(testScorcardFile); err != nil {
+		return fmt.Errorf("upsertTestDoc error reading test scorecard file %v", err)
+	}
+	scorecardBytes, _ := os.ReadFile(testScorcardFile)
+	var scorecard map[string]interface{}
+	err := json.Unmarshal(scorecardBytes, &scorecard)
+	if err != nil {
+		return fmt.Errorf("upsertTestDoc error unmarshalling test scorecard file %v", err)
+	}
+	// upsert the test scorecard document
+	_, err = mngr.cb.Collection.Upsert("SCTEST:test_scorecard", scorecard, nil)
+	if err != nil {
+		return fmt.Errorf("upsertTestDoc error upserting test scorecard file %v", err)
+	}
+	return nil
 }
 
 func TestDirector_test_connection(t *testing.T) {
@@ -158,25 +160,24 @@ func Test_loadEnvironmant(t *testing.T) {
 	}
 }
 
-
 func Test_getQueryBlocks(t *testing.T) {
 	// setup a test document
 	var documentId string = "SCTEST:test_scorecard"
 	var mngr *Manager
 	var err error
-	var environmentFile = fmt.Sprint(os.Getenv("HOME"), "/vxDataProcessor.env")
+	environmentFile := fmt.Sprint(os.Getenv("HOME"), "/vxDataProcessor.env")
 	mngr, err = GetManager("SC", environmentFile, documentId)
 	if err != nil {
-		t.Fatal (fmt.Errorf("manager loadEnvironmant error GetManager %q", err))
+		t.Fatal(fmt.Errorf("manager loadEnvironmant error GetManager %q", err))
 	}
 	var cbCredentials director.DbCredentials
 	_, cbCredentials, err = loadEnvironmant(mngr.environmentFile)
 	if err != nil {
-		t.Fatal (fmt.Errorf("manager loadEnvironmant error loadEnvironmant %q", err))
+		t.Fatal(fmt.Errorf("manager loadEnvironmant error loadEnvironmant %q", err))
 	}
 	err = getConnection(mngr, cbCredentials)
 	if err != nil {
-		t.Fatal (fmt.Errorf("manager loadEnvironmant error getConnection %q", err))
+		t.Fatal(fmt.Errorf("manager loadEnvironmant error getConnection %q", err))
 	}
 	err = upsertTestDoc(mngr)
 	if err != nil {
@@ -192,9 +193,9 @@ func Test_getQueryBlocks(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "queryMaps",
-			args: mngr,
-			want: []string{"Block0", "Block1"},
+			name:    "queryMaps",
+			args:    mngr,
+			want:    []string{"Block0", "Block1"},
 			wantErr: false,
 		},
 	}
@@ -225,19 +226,19 @@ func Test_getSliceResultBlocks(t *testing.T) {
 	var documentId string = "SCTEST:test_scorecard"
 	var mngr *Manager
 	var err error
-	var environmentFile = fmt.Sprint(os.Getenv("HOME"), "/vxDataProcessor.env")
+	environmentFile := fmt.Sprint(os.Getenv("HOME"), "/vxDataProcessor.env")
 	mngr, err = GetManager("SC", environmentFile, documentId)
 	if err != nil {
-		t.Fatal (fmt.Errorf("manager loadEnvironmant error GetManager %q", err))
+		t.Fatal(fmt.Errorf("manager loadEnvironmant error GetManager %q", err))
 	}
 	var cbCredentials director.DbCredentials
 	_, cbCredentials, err = loadEnvironmant(mngr.environmentFile)
 	if err != nil {
-		t.Fatal (fmt.Errorf("manager loadEnvironmant error loadEnvironmant %q", err))
+		t.Fatal(fmt.Errorf("manager loadEnvironmant error loadEnvironmant %q", err))
 	}
 	err = getConnection(mngr, cbCredentials)
 	if err != nil {
-		t.Fatal (fmt.Errorf("manager loadEnvironmant error getConnection %q", err))
+		t.Fatal(fmt.Errorf("manager loadEnvironmant error getConnection %q", err))
 	}
 	err = upsertTestDoc(mngr)
 	if err != nil {
@@ -253,9 +254,9 @@ func Test_getSliceResultBlocks(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "curves",
-			args: mngr,
-			want: []string{"application","color","control-data-source","data-source","forecast-length","label","level","region","statistic","threshold","truth","valid-time","variable"},
+			name:    "curves",
+			args:    mngr,
+			want:    []string{"application", "color", "control-data-source", "data-source", "forecast-length", "label", "level", "region", "statistic", "threshold", "truth", "valid-time", "variable"},
 			wantErr: false,
 		},
 	}
@@ -286,21 +287,21 @@ func Test_runManager(t *testing.T) {
 	var documentId string = "SCTEST:test_scorecard"
 	var mngr *Manager
 	var err error
-	var environmentFile = fmt.Sprint(os.Getenv("HOME"), "/vxDataProcessor.env")
+	environmentFile := fmt.Sprint(os.Getenv("HOME"), "/vxDataProcessor.env")
 	start := time.Now()
 
 	mngr, err = GetManager("SC", environmentFile, documentId)
 	if err != nil {
-		t.Fatal (fmt.Errorf("manager loadEnvironmant error GetManager %q", err))
+		t.Fatal(fmt.Errorf("manager loadEnvironmant error GetManager %q", err))
 	}
 	var cbCredentials director.DbCredentials
 	_, cbCredentials, err = loadEnvironmant(mngr.environmentFile)
 	if err != nil {
-		t.Fatal (fmt.Errorf("manager loadEnvironmant error loadEnvironmant %q", err))
+		t.Fatal(fmt.Errorf("manager loadEnvironmant error loadEnvironmant %q", err))
 	}
 	err = getConnection(mngr, cbCredentials)
 	if err != nil {
-		t.Fatal (fmt.Errorf("manager loadEnvironmant error getConnection %q", err))
+		t.Fatal(fmt.Errorf("manager loadEnvironmant error getConnection %q", err))
 	}
 	err = upsertTestDoc(mngr)
 	if err != nil {


### PR DESCRIPTION
Apply `gofumpt` (plus a few other linters) to our codebase. Gofumpt is a more modern version of `gofmt`. I had originally intended to set up `gofmt` to make sure our code was automatically formatted. However, it appears it wasn't part of the default linter package in `golangci-lint`.