### PR TITLE
Handle duplicate jobs submitted to the api

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -14,7 +14,7 @@ import (
 // their handlers
 func SetupRouter(js *jobstore.JobStore) *gin.Engine {
 	router := gin.Default()
-	server := NewJobServer(js)
+	server := newJobServer(js)
 
 	router.POST("/jobs/", server.createJobHandler)
 	router.GET("/jobs/", server.getAllJobsHandler)

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -14,7 +14,7 @@ func TestPingEndpoint(t *testing.T) {
 	router := SetupRouter(nil)
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/ping", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/ping", http.NoBody)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -27,10 +27,10 @@ func TestJobsEndpoint(t *testing.T) {
 
 		// Setup
 		w := httptest.NewRecorder()
-		var jsonStr = []byte(`{"docid": "myid1"}`)
+		jsonStr := []byte(`{"docid": "myid1"}`)
 
 		// Test
-		req, _ := http.NewRequest("POST", "/jobs/", bytes.NewBuffer(jsonStr))
+		req, _ := http.NewRequest(http.MethodPost, "/jobs/", bytes.NewBuffer(jsonStr))
 		router.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
@@ -43,14 +43,14 @@ func TestJobsEndpoint(t *testing.T) {
 		// Setup
 		// TODO - is there a better way to insert state?
 		w := httptest.NewRecorder()
-		var jsonStr = []byte(`{"docid": "myid1"}`)
-		req, _ := http.NewRequest("POST", "/jobs/", bytes.NewBuffer(jsonStr))
+		jsonStr := []byte(`{"docid": "myid1"}`)
+		req, _ := http.NewRequest(http.MethodPost, "/jobs/", bytes.NewBuffer(jsonStr))
 		router.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
 
 		// Test
 		w = httptest.NewRecorder()
-		req, _ = http.NewRequest("GET", "/jobs/", nil)
+		req, _ = http.NewRequest(http.MethodGet, "/jobs/", http.NoBody)
 		router.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
@@ -63,14 +63,14 @@ func TestJobsIDEndpoint(t *testing.T) {
 
 	// Setup
 	w := httptest.NewRecorder()
-	var jsonStr = []byte(`{"docid": "myid1"}`)
-	req, _ := http.NewRequest("POST", "/jobs/", bytes.NewBuffer(jsonStr))
+	jsonStr := []byte(`{"docid": "myid1"}`)
+	req, _ := http.NewRequest(http.MethodPost, "/jobs/", bytes.NewBuffer(jsonStr))
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	// Test
 	w = httptest.NewRecorder()
-	req, _ = http.NewRequest("GET", "/jobs/0", nil)
+	req, _ = http.NewRequest(http.MethodGet, "/jobs/0", http.NoBody)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -99,11 +99,11 @@ func TestWorker(t *testing.T) {
 			case got1 := <-status:
 				got2 := <-status // ignore the processing status
 				proc.lock.Lock()
-				defer proc.lock.Unlock()
 				assert.Equal(t, want[0], got1)
 				assert.Equal(t, "foo", proc.DocID)
 				assert.Equal(t, true, proc.Processed)
 				assert.Equal(t, want[1], got2)
+				proc.lock.Unlock()
 				return
 			default:
 				continue

--- a/pkg/api/jobserver.go
+++ b/pkg/api/jobserver.go
@@ -39,13 +39,16 @@ func (js *jobServer) createJobHandler(c *gin.Context) {
 
 	var rj RequestJob
 	if err := c.ShouldBindJSON(&rj); err != nil {
-		c.String(http.StatusBadRequest, err.Error()) //TODO: Better error message
+		c.String(http.StatusBadRequest, err.Error()) // TODO: Better error message
 		return
 	}
 
 	id, err := js.store.CreateJob(rj.DocID)
-	if err != nil {
-		c.String(http.StatusInternalServerError, err.Error()) //TODO: Better error message
+	if err.Error() == "docID already exists" {
+		c.String(http.StatusBadRequest, err.Error())
+		return
+	} else if err != nil {
+		c.String(http.StatusInternalServerError, err.Error()) // TODO: Better error message
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"id": id})

--- a/pkg/api/jobserver.go
+++ b/pkg/api/jobserver.go
@@ -17,7 +17,7 @@ type jobServer struct {
 //
 // It can take a pointer to an existing JobStore to store Jobs in. If nil is
 // passed instead of a JobStore, it will initialize an empty JobStore for you.
-func NewJobServer(js *jobstore.JobStore) *jobServer {
+func newJobServer(js *jobstore.JobStore) *jobServer {
 	if js == nil {
 		js = jobstore.NewJobStore()
 	}

--- a/pkg/api/jobserver_test.go
+++ b/pkg/api/jobserver_test.go
@@ -96,4 +96,20 @@ func Test_jobServer_createJobHandler(t *testing.T) {
 
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
+
+	t.Run("Test a duplicate job submission", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		jsonStr := []byte(`{"docid": "json"}`)
+		c.Request, _ = http.NewRequest(http.MethodPost, "/jobs/", bytes.NewBuffer(jsonStr))
+
+		store := jobstore.NewJobStore()
+		_, _ = store.CreateJob("json")
+		js := NewJobServer(store)
+
+		js.createJobHandler(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, "docID already exists", w.Body.String())
+	})
 }

--- a/pkg/api/jobserver_test.go
+++ b/pkg/api/jobserver_test.go
@@ -42,7 +42,7 @@ func TestNewJobServer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewJobServer(tt.args.js); !reflect.DeepEqual(got, tt.want) {
+			if got := newJobServer(tt.args.js); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewJobServer() = %v, want %v", got, tt.want)
 			}
 		})
@@ -53,7 +53,7 @@ func Test_jobServer_getAllJobsHandler(t *testing.T) {
 	t.Run("Test getting an empty jobstore", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
-		NewJobServer(nil).getAllJobsHandler(c)
+		newJobServer(nil).getAllJobsHandler(c)
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, `[]`, w.Body.String())
@@ -66,7 +66,7 @@ func Test_jobServer_getAllJobsHandler(t *testing.T) {
 		}
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
-		js := NewJobServer(nil)
+		js := newJobServer(nil)
 
 		_, _ = js.store.CreateJob("foo")
 		_, _ = js.store.CreateJob("bar")
@@ -90,7 +90,7 @@ func Test_jobServer_createJobHandler(t *testing.T) {
 		jsonStr := []byte(`{"random": "json"}`)
 		c.Request, _ = http.NewRequest(http.MethodPost, "/jobs/", bytes.NewBuffer(jsonStr))
 
-		js := NewJobServer(nil)
+		js := newJobServer(nil)
 
 		js.createJobHandler(c)
 
@@ -105,7 +105,7 @@ func Test_jobServer_createJobHandler(t *testing.T) {
 
 		store := jobstore.NewJobStore()
 		_, _ = store.CreateJob("json")
-		js := NewJobServer(store)
+		js := newJobServer(store)
 
 		js.createJobHandler(c)
 

--- a/pkg/api/jobserver_test.go
+++ b/pkg/api/jobserver_test.go
@@ -87,8 +87,8 @@ func Test_jobServer_createJobHandler(t *testing.T) {
 	t.Run("Test a bad job submission", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
-		var jsonStr = []byte(`{"random": "json"}`)
-		c.Request, _ = http.NewRequest("POST", "/jobs/", bytes.NewBuffer(jsonStr))
+		jsonStr := []byte(`{"random": "json"}`)
+		c.Request, _ = http.NewRequest(http.MethodPost, "/jobs/", bytes.NewBuffer(jsonStr))
 
 		js := NewJobServer(nil)
 

--- a/pkg/api/jobstore/jobstore_test.go
+++ b/pkg/api/jobstore/jobstore_test.go
@@ -19,8 +19,9 @@ func TestNewJobStore(t *testing.T) {
 		{
 			name: "Test New Job Store",
 			want: &JobStore{
-				jobs:   map[int]Job{},
-				nextID: 0,
+				jobs:         map[int]Job{},
+				reverseIndex: map[string]int{},
+				nextID:       0,
 			},
 		},
 	}
@@ -100,9 +101,19 @@ func TestJobStore_CreateJob(t *testing.T) {
 		wg.Wait()
 
 		assert.Equal(t, wantedCount, len(js.jobs))
-
 	})
-	// TODO - what happens if we get the same docID submitted multiple times?
+
+	t.Run("Test creating duplicate jobs", func(t *testing.T) {
+		js := NewJobStore()
+		wantErr := "docID already exists"
+
+		_, _ = js.CreateJob("foo")
+		_, gotErr := js.CreateJob("foo")
+
+		if assert.NotNil(t, gotErr) {
+			assert.Equal(t, gotErr.Error(), wantErr)
+		}
+	})
 }
 
 func TestJobStore_GetJob(t *testing.T) {

--- a/pkg/api/jobstore/jobstore_test.go
+++ b/pkg/api/jobstore/jobstore_test.go
@@ -326,7 +326,5 @@ func TestJobStore_updateJobStatus(t *testing.T) {
 		if err.Error() != want {
 			t.Errorf("JobStore.updateJobStatus got error '%v', wanted error '%v'", err.Error(), want)
 		}
-
 	})
-
 }


### PR DESCRIPTION
Add a reverse index to the jobstore so we can easily look up if particular docID's have already been added. Send a "Bad Request" HTTP code to the client if we detect a duplicate ID.