### PR TITLE
Load settings from a .env file

### DIFF
--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"log"
+	"os"
+
 	"github.com/NOAA-GSL/vxDataProcessor/pkg/api"
 	"github.com/NOAA-GSL/vxDataProcessor/pkg/api/jobstore"
 	"github.com/NOAA-GSL/vxDataProcessor/pkg/manager"
+	"github.com/joho/godotenv"
 )
 
 // ProcessorFactory is a wrapper function to satisfy the requirements of
@@ -13,6 +17,20 @@ func processorFactory(docID string) (api.Processor, error) {
 }
 
 func main() {
+	environmentFile, set := os.LookupEnv("PROC_ENV_PATH")
+	if !set {
+		err := godotenv.Load() // Loads from "$(pwd)/.env"
+		if err != nil {
+			log.Printf("Info - Unable to load .env file - %v", err)
+		}
+	} else {
+		err := godotenv.Load(environmentFile) // Loads from whatever PROC_ENV_PATH has been set to
+		if err != nil {
+			log.Printf("Error - Couldn't load requested environment file at %q, error: %v", environmentFile, err)
+			return
+		}
+	}
+
 	// TODO - benchmark if it'd be better if these channels were buffered. They will block until a receiver frees up.
 	jobs := make(chan jobstore.Job)
 	status := make(chan jobstore.Job)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -53,18 +53,20 @@ func Worker(id int, getProcessor func(string) (Processor, error), jobs <-chan jo
 
 		mgr, err := getProcessor(job.DocID)
 		if err != nil {
+			fmt.Printf("Error: Job %v - %v\n", job.DocID, err)
 			job.Status = jobstore.StatusFailed
 			status <- job
-			return
+			continue
 		}
 
 		err = mgr.Run()
 		duration := time.Since(start).Seconds()
 		calculationDuration.WithLabelValues(job.DocID).Observe(duration)
 		if err != nil {
+			fmt.Printf("Error: Job %v - %v\n", job.DocID, err)
 			job.Status = jobstore.StatusFailed
 			status <- job
-			return
+			continue
 		}
 
 		// report status

--- a/pkg/manager/iManager.go
+++ b/pkg/manager/iManager.go
@@ -51,5 +51,5 @@ func GetManager(documentID string) (*Manager, error) {
 			return newScorecardManager(documentID)
 		}
 	}
-	return nil, fmt.Errorf("Manager GetManager unsupported managerType: %q", documentType)
+	return nil, fmt.Errorf("Manager GetManager unsupported documentType: %q", documentType)
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -328,11 +328,8 @@ func processRegion(
 
 func (mngr Manager) Run() (err error) {
 	// load the environment
-	var mysqlCredentials, cbCredentials director.DbCredentials
-	var minorThreshold float64
-	var majorThreshold float64
 	// initially unknown
-	mysqlCredentials, cbCredentials, err = loadEnvironment()
+	mysqlCredentials, cbCredentials, err := loadEnvironment()
 	if err != nil {
 		return fmt.Errorf("manager loadEnvironmant error %q", err)
 	}
@@ -350,7 +347,7 @@ func (mngr Manager) Run() (err error) {
 		err = fmt.Errorf("manager Run error getting plotParamCurves: %q", err)
 		return err
 	}
-	minorThreshold, majorThreshold, err = getThresholds(plotParams)
+	minorThreshold, majorThreshold, err := getThresholds(plotParams)
 	if err != nil {
 		err = fmt.Errorf("manager Run error getting thresholds: %q", err)
 		return err

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -112,7 +112,6 @@ func TestDirector_test_connection(t *testing.T) {
 func Test_loadEnvironment(t *testing.T) {
 	tests := []struct {
 		name                 string
-		args                 string
 		wantMysqlCredentials director.DbCredentials
 		wantCbCredentials    director.DbCredentials
 		wantErr              bool


### PR DESCRIPTION
Load .env files if they're present. Additionally, fix a bug where the worker would quit if it had a failed job.