### PR TITLE
Reject job requests with invalid doc types

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -57,12 +57,12 @@ func TestPingEndpoint(t *testing.T) {
 }
 
 func TestJobsEndpoint(t *testing.T) {
-	t.Run("Test Creating a Job", func(t *testing.T) {
+	t.Run("Test creating a Job", func(t *testing.T) {
 		router := SetupRouter(nil)
 
 		// Setup
 		w := httptest.NewRecorder()
-		jsonStr := []byte(`{"docid": "myid1"}`)
+		jsonStr := []byte(`{"docid": "SC:myid1"}`)
 
 		// Test
 		req, _ := http.NewRequest(http.MethodPost, "/jobs/", bytes.NewBuffer(jsonStr))
@@ -72,13 +72,28 @@ func TestJobsEndpoint(t *testing.T) {
 		assert.Equal(t, `{"id":0}`, w.Body.String())
 	})
 
+	t.Run("Test creating an invalid Job type", func(t *testing.T) {
+		router := SetupRouter(nil)
+
+		// Setup
+		w := httptest.NewRecorder()
+		jsonStr := []byte(`{"docid": "Err:myid1"}`)
+
+		// Test
+		req, _ := http.NewRequest(http.MethodPost, "/jobs/", bytes.NewBuffer(jsonStr))
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, "Unknown scorecard document type Err", w.Body.String())
+	})
+
 	t.Run("Test Getting All Jobs", func(t *testing.T) {
 		router := SetupRouter(nil)
 
 		// Setup
 		// TODO - is there a better way to insert state?
 		w := httptest.NewRecorder()
-		jsonStr := []byte(`{"docid": "myid1"}`)
+		jsonStr := []byte(`{"docid": "SC:myid1"}`)
 		req, _ := http.NewRequest(http.MethodPost, "/jobs/", bytes.NewBuffer(jsonStr))
 		router.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
@@ -89,7 +104,7 @@ func TestJobsEndpoint(t *testing.T) {
 		router.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Equal(t, `[{"id":0,"docid":"myid1","status":"created"}]`, w.Body.String())
+		assert.Equal(t, `[{"id":0,"docid":"SC:myid1","status":"created"}]`, w.Body.String())
 	})
 }
 
@@ -98,7 +113,7 @@ func TestJobsIDEndpoint(t *testing.T) {
 
 	// Setup
 	w := httptest.NewRecorder()
-	jsonStr := []byte(`{"docid": "myid1"}`)
+	jsonStr := []byte(`{"docid": "SC:myid1"}`)
 	req, _ := http.NewRequest(http.MethodPost, "/jobs/", bytes.NewBuffer(jsonStr))
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -109,7 +124,7 @@ func TestJobsIDEndpoint(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, `{"id":0,"docid":"myid1","status":"created"}`, w.Body.String())
+	assert.Equal(t, `{"id":0,"docid":"SC:myid1","status":"created"}`, w.Body.String())
 }
 
 func TestWorker(t *testing.T) {

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -78,13 +79,22 @@ func TestJobsEndpoint(t *testing.T) {
 		// Setup
 		w := httptest.NewRecorder()
 		jsonStr := []byte(`{"docid": "Err:myid1"}`)
+		want := errResponse{
+			Code:    http.StatusBadRequest,
+			Message: "Invalid scorecard document type Err",
+		}
 
 		// Test
 		req, _ := http.NewRequest(http.MethodPost, "/jobs/", bytes.NewBuffer(jsonStr))
 		router.ServeHTTP(w, req)
+		got := errResponse{}
+		err := json.Unmarshal(w.Body.Bytes(), &got)
+		if err != nil {
+			t.Fatal("Issue unmarshalling JSON response")
+		}
 
 		assert.Equal(t, http.StatusBadRequest, w.Code)
-		assert.Equal(t, "Unknown scorecard document type Err", w.Body.String())
+		assert.Equal(t, want, got)
 	})
 
 	t.Run("Test Getting All Jobs", func(t *testing.T) {

--- a/pkg/api/jobserver.go
+++ b/pkg/api/jobserver.go
@@ -33,8 +33,8 @@ func (js *jobServer) getAllJobsHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, allJobs)
 }
 
-// isAcceptableDocType tests the scorecard docType passed in to make sure it's valid
-func isAcceptableDocType(docType string) bool {
+// isValidDocType tests the scorecard docType passed in to make sure it's valid
+func isValidDocType(docType string) bool {
 	switch docType {
 	case "SC":
 		return true
@@ -57,7 +57,7 @@ func (js *jobServer) createJobHandler(c *gin.Context) {
 
 	// test the DocID is a valid type
 	docType := strings.Split(rj.DocID, ":")[0]
-	if !isAcceptableDocType(docType) {
+	if !isValidDocType(docType) {
 		c.String(http.StatusBadRequest, fmt.Sprintf("Unknown scorecard document type %v", docType)) // TODO: Better error message
 		return
 	}

--- a/pkg/api/jobserver.go
+++ b/pkg/api/jobserver.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/NOAA-GSL/vxDataProcessor/pkg/api/jobstore"
 	"github.com/gin-gonic/gin"
@@ -31,6 +33,16 @@ func (js *jobServer) getAllJobsHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, allJobs)
 }
 
+// isAcceptableDocType tests the scorecard docType passed in to make sure it's valid
+func isAcceptableDocType(docType string) bool {
+	switch docType {
+	case "SC":
+		return true
+	default:
+		return false
+	}
+}
+
 // createJobHandler handles requests to create a new Job in the store
 func (js *jobServer) createJobHandler(c *gin.Context) {
 	type RequestJob struct {
@@ -40,6 +52,13 @@ func (js *jobServer) createJobHandler(c *gin.Context) {
 	var rj RequestJob
 	if err := c.ShouldBindJSON(&rj); err != nil {
 		c.String(http.StatusBadRequest, err.Error()) // TODO: Better error message
+		return
+	}
+
+	// test the DocID is a valid type
+	docType := strings.Split(rj.DocID, ":")[0]
+	if !isAcceptableDocType(docType) {
+		c.String(http.StatusBadRequest, fmt.Sprintf("Unknown scorecard document type %v", docType)) // TODO: Better error message
 		return
 	}
 

--- a/pkg/api/jobserver_test.go
+++ b/pkg/api/jobserver_test.go
@@ -87,7 +87,7 @@ func Test_jobServer_createJobHandler(t *testing.T) {
 	t.Run("Test a bad job submission", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
-		jsonStr := []byte(`{"random": "json"}`)
+		jsonStr := []byte(`{"random": "SC:json"}`)
 		c.Request, _ = http.NewRequest(http.MethodPost, "/jobs/", bytes.NewBuffer(jsonStr))
 
 		js := newJobServer(nil)
@@ -100,11 +100,11 @@ func Test_jobServer_createJobHandler(t *testing.T) {
 	t.Run("Test a duplicate job submission", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
-		jsonStr := []byte(`{"docid": "json"}`)
+		jsonStr := []byte(`{"docid": "SC:json"}`)
 		c.Request, _ = http.NewRequest(http.MethodPost, "/jobs/", bytes.NewBuffer(jsonStr))
 
 		store := jobstore.NewJobStore()
-		_, _ = store.CreateJob("json")
+		_, _ = store.CreateJob("SC:json")
 		js := newJobServer(store)
 
 		js.createJobHandler(c)

--- a/pkg/api/jobserver_test.go
+++ b/pkg/api/jobserver_test.go
@@ -139,3 +139,76 @@ func Test_jobServer_createJobHandler(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 }
+
+func Test_jobServer_getJobHandler(t *testing.T) {
+	t.Run("Test getting a job", func(t *testing.T) {
+		want := jobstore.Job{ID: 0, DocID: "foo", Status: jobstore.StatusCreated}
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/jobs/0/", http.NoBody)
+		c.Params = []gin.Param{{Key: "id", Value: "0"}}
+		js := newJobServer(nil)
+
+		_, _ = js.store.CreateJob("foo")
+
+		js.getJobHandler(c)
+		got := jobstore.Job{}
+		err := json.Unmarshal(w.Body.Bytes(), &got)
+		if err != nil {
+			t.Fatal("Issue unmarshalling JSON response")
+		}
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("Test an invalid request", func(t *testing.T) {
+		want := errResponse{
+			Code:    http.StatusBadRequest,
+			Message: "Unable to parse job id \"stuff\", an int is required",
+		}
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/jobs/stuff", http.NoBody)
+		c.Params = []gin.Param{{Key: "id", Value: "stuff"}}
+		js := newJobServer(nil)
+
+		_, _ = js.store.CreateJob("foo")
+		_, _ = js.store.CreateJob("bar")
+
+		js.getJobHandler(c)
+		got := errResponse{}
+		err := json.Unmarshal(w.Body.Bytes(), &got)
+		if err != nil {
+			t.Fatal("Issue unmarshalling JSON response")
+		}
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("Test an invalid job", func(t *testing.T) {
+		want := errResponse{
+			Code:    http.StatusNotFound,
+			Message: "job with id=3 not found",
+		}
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/jobs/3", http.NoBody)
+		c.Params = []gin.Param{{Key: "id", Value: "3"}}
+		js := newJobServer(nil)
+
+		_, _ = js.store.CreateJob("foo")
+		_, _ = js.store.CreateJob("bar")
+
+		js.getJobHandler(c)
+		got := errResponse{}
+		err := json.Unmarshal(w.Body.Bytes(), &got)
+		if err != nil {
+			t.Fatal("Issue unmarshalling JSON response")
+		}
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+		assert.Equal(t, want, got)
+	})
+}


### PR DESCRIPTION
Test the DocID in the POST request for valid document types like "SC". Return a BadRequest HTTP response if the doctype isn't accepted.