### PR TITLE
Fixes for the Goroutine Leak

### DIFF
--- a/cmd/cli/process.go
+++ b/cmd/cli/process.go
@@ -41,6 +41,12 @@ func process() int {
 	}
 
 	mngr, err := manager.GetManager(documentID)
+	defer func() {
+		errd := mngr.Close()
+		if errd != nil {
+			log.Printf("Error cleaning up manager: %q", errd)
+		}
+	}()
 	if err != nil {
 		log.Printf("manager loadEnvironmant error GetManager %q", err)
 		return 2

--- a/cmd/cli/process.go
+++ b/cmd/cli/process.go
@@ -41,14 +41,8 @@ func process() int {
 	}
 
 	mngr, err := manager.GetManager(documentID)
-	defer func() {
-		errd := mngr.Close()
-		if errd != nil {
-			log.Printf("Error cleaning up manager: %q", errd)
-		}
-	}()
 	if err != nil {
-		log.Printf("manager loadEnvironmant error GetManager %q", err)
+		log.Printf("manager error GetManager %q", err)
 		return 2
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/prometheus/client_golang v1.15.0
 	github.com/stretchr/testify v1.8.2
+	go.uber.org/goleak v1.2.1
 	golang.org/x/sync v0.1.0
 )
 
@@ -43,7 +44,6 @@ require (
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.9 // indirect
-	go.uber.org/goleak v1.2.1 // indirect
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
 	golang.org/x/crypto v0.7.0 // indirect
 	golang.org/x/net v0.8.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.9 // indirect
+	go.uber.org/goleak v1.2.1 // indirect
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
 	golang.org/x/crypto v0.7.0 // indirect
 	golang.org/x/net v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.9 h1:rmenucSohSTiyL09Y+l2OCk+FrMxGMzho2+tjr5ticU=
 github.com/ugorji/go/codec v1.2.9/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
+go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670 h1:18EFjUmQOcUvxNYSkA6jO9VAiXCnxFY6NyDX0bHDmkU=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/crypto v0.7.0 h1:AvwMYaRytfdeVt3u6mLaxYtErKYjxA2OXjJ1HHq6t3A=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -37,6 +37,7 @@ func SetupRouter(js *jobstore.JobStore) *gin.Engine {
 // processor is intended to encapsulate the manager.manager struct
 type Processor interface {
 	Run() error
+	Close() error
 }
 
 // Worker receives jobs on a channel, processes them, and reports the status on a return channel
@@ -64,10 +65,14 @@ func Worker(id int, getProcessor func(string) (Processor, error), jobs <-chan jo
 		calculationDuration.WithLabelValues(job.DocID).Observe(duration)
 		if err != nil {
 			fmt.Printf("Error: Job %v - %v\n", job.DocID, err)
+			err = mgr.Close()
+			fmt.Printf("Error: Job %v - %v\n", job.DocID, err)
 			job.Status = jobstore.StatusFailed
 			status <- job
 			continue
 		}
+		err = mgr.Close()
+		fmt.Printf("Error: Job %v - %v\n", job.DocID, err)
 
 		// report status
 		job.Status = jobstore.StatusCompleted

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -34,6 +34,11 @@ func (tp *TestProcess) Run() error {
 	return nil
 }
 
+// Close is a dummy method for testing that satisfies the Processor interface
+func (tp *TestProcess) Close() error {
+	return nil
+}
+
 func ProcessorFactoryMock(docID string) (Processor, error) {
 	documentType := strings.Split(docID, ":")[0]
 	switch documentType {

--- a/pkg/builder/TestTwoSampleTTestBuilder_test.go
+++ b/pkg/builder/TestTwoSampleTTestBuilder_test.go
@@ -3,6 +3,8 @@ package builder
 import (
 	"fmt"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 var (
@@ -14,6 +16,7 @@ var (
 
 // test for zero variance
 func TestTwoSampleTTestBuilder_test_identical(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	err := cellPtr.SetGoodnessPolarity(gp)
 	if err != nil {
 		t.Fatal(fmt.Sprint("TestTwoSampleTTestBuilder_test_identical - SetGoodnessPolarity - error message : ", err))
@@ -65,6 +68,7 @@ func TestTwoSampleTTestBuilder_test_identical(t *testing.T) {
 
 // this BIAS test has inputs that should return a value of 2
 func TestTwoSampleTTestBuilder_test_BIAS_2(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	cellPtr := NewTwoSampleTTestBuilder()
 	err := cellPtr.SetGoodnessPolarity(gp)
 	if err != nil {
@@ -118,6 +122,7 @@ func TestTwoSampleTTestBuilder_test_BIAS_2(t *testing.T) {
 
 // this test has inputs that should return a value of -2
 func TestTwoSampleTTestBuilder_test_neagtive_2(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	cellPtr := NewTwoSampleTTestBuilder()
 	err := cellPtr.SetGoodnessPolarity(gp)
 	if err != nil {
@@ -171,6 +176,7 @@ func TestTwoSampleTTestBuilder_test_neagtive_2(t *testing.T) {
 
 // this test has inputs that should return a value of 1
 func TestTwoSampleTTestBuilder_test_1(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	err := cellPtr.SetGoodnessPolarity(gp)
 	if err != nil {
 		t.Fatal(fmt.Sprint("TestTwoSampleTTestBuilder_test_1 - SetGoodnessPolarity - error message : ", err))
@@ -225,6 +231,7 @@ func TestTwoSampleTTestBuilder_test_1(t *testing.T) {
 
 // this test has inputs that should return a value of 0
 func TestTwoSampleTTestBuilder_test_0(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	err := cellPtr.SetGoodnessPolarity(gp)
 	if err != nil {
 		t.Fatal(fmt.Sprint("TestTwoSampleTTestBuilder_test_0 - SetGoodnessPolarity - error message : ", err))
@@ -280,6 +287,7 @@ func TestTwoSampleTTestBuilder_test_0(t *testing.T) {
 }
 
 func TestTwoSampleTTestBuilder_different_lengths(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	err := cellPtr.SetGoodnessPolarity(gp)
 	if err != nil {
 		t.Fatal(fmt.Sprint("SampleTTestBuilder_diff - SetGoodnessPolarity - error message : ", err))
@@ -329,6 +337,7 @@ func TestTwoSampleTTestBuilder_different_lengths(t *testing.T) {
 
 // this test has inputs that should return a value of 1 after matching (ctl missing one element)
 func TestTwoSampleTTestBuilder_test__match_ctl_short_1(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	err := cellPtr.SetGoodnessPolarity(gp)
 	if err != nil {
 		t.Fatal(fmt.Sprint("TestTwoSampleTTestBuilder_test_1 - SetGoodnessPolarity - error message : ", err))
@@ -387,6 +396,7 @@ func TestTwoSampleTTestBuilder_test__match_ctl_short_1(t *testing.T) {
 
 // this test has inputs that should return a value of 1 after matching (exp missing one element)
 func TestTwoSampleTTestBuilder_test__match_exp_short_1(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	err := cellPtr.SetGoodnessPolarity(gp)
 	if err != nil {
 		t.Fatal(fmt.Sprint("TestTwoSampleTTestBuilder_test_1 - SetGoodnessPolarity - error message : ", err))
@@ -445,6 +455,7 @@ func TestTwoSampleTTestBuilder_test__match_exp_short_1(t *testing.T) {
 
 // this test has inputs that should return a value of 0 exp missing all data)
 func TestTwoSampleTTestBuilder_test__missing_one_population(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	err := cellPtr.SetGoodnessPolarity(gp)
 	if err != nil {
 		t.Fatal(fmt.Sprint("TestTwoSampleTTestBuilder_test__missing_one_population - SetGoodnessPolarity - error message : ", err))

--- a/pkg/builder/builder_stats_test.go
+++ b/pkg/builder/builder_stats_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 )
 
 func getDataSet(epoch int64, ctlValues []float64, expValues []float64) DataSet {
@@ -28,6 +29,7 @@ func getDataSet(epoch int64, ctlValues []float64, expValues []float64) DataSet {
 }
 
 func TestGetMatchedDataSet(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	epoch := time.Now().Unix()
 	tests := []struct {
 		name    string
@@ -109,6 +111,7 @@ func TestGetMatchedDataSet(t *testing.T) {
 
 // this test has inputs captured from a real world example
 func TestGetMatchedDataSetRealWorld(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	var ctlData, expData PreCalcRecords
 	var dataSet DataSet
 	ctlData = append(ctlData, PreCalcRecord{Avtime: 1678788000, Stat: 0})
@@ -878,6 +881,7 @@ func Test_calculateStatScalar(t *testing.T) {
 	   running the associated test_data/{stat}.sql query.
 	*/
 
+	defer goleak.VerifyNone(t)
 	type args struct {
 		squareDiffSum   float64
 		NSum            float64

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -22,6 +22,7 @@ func NotifyScorecard(baseURL, docID string) error {
 		return fmt.Errorf("client: error making http request: %w", err)
 	}
 	defer res.Body.Close()
+	defer http.DefaultClient.CloseIdleConnections()
 
 	if res.StatusCode != http.StatusOK {
 		return fmt.Errorf("client: got response code %d from %v", res.StatusCode, scorecardURL)
@@ -60,6 +61,7 @@ func NotifyScorecardStatus(baseURL, docID, status string, err error) error {
 		return fmt.Errorf("client: error making http request: %w", err)
 	}
 	defer res.Body.Close()
+	defer http.DefaultClient.CloseIdleConnections()
 
 	if res.StatusCode != http.StatusOK {
 		return fmt.Errorf("client: got response code %d from %v", res.StatusCode, scorecardURL)

--- a/pkg/director/iDirector.go
+++ b/pkg/director/iDirector.go
@@ -45,11 +45,13 @@ type Director struct {
 	dateRange        DateRange
 	minorThreshold   float64
 	majorThreshold   float64
+	statistics       []string
+	statisticType    string
 }
 
 type DirectorBuilder interface {
-	// datasourceName like user:password@tcp(hostname:3306)/dbname
 	Run(regionMap ScorecardBlock, queryMap ScorecardBlock)
+	Close() error
 }
 
 type DateRange struct {
@@ -57,9 +59,10 @@ type DateRange struct {
 	ToSecs   int64
 }
 
+// GetDirector returns a correctly initizalized director. Callers should make sure to call Close() when they're done with the director.
 func GetDirector(directorType string, mysqlCredentials DbCredentials, dateRange DateRange, minorThreshold float64, majorThreshold float64) (*Director, error) {
 	if directorType == "MysqlDirector" {
-		return NewMysqlDirector(mysqlCredentials, dateRange, minorThreshold, majorThreshold)
+		return newMySQLDirector(mysqlCredentials, dateRange, minorThreshold, majorThreshold)
 	} else {
 		return nil, fmt.Errorf("Director GetDirector unsupported directorType: %q", directorType)
 	}

--- a/pkg/director/mysql_director.go
+++ b/pkg/director/mysql_director.go
@@ -39,8 +39,8 @@ const (
 	convertingNull = "converting NULL"
 )
 
-// ExtractKeys returns a slice containing the keys in the given map
-func ExtractKeys[K comparable, V any](m map[K]V) []K {
+// getMapKeys returns an unsorted slice containing the keys in the given map
+func getMapKeys[K comparable, V any](m map[K]V) []K {
 	keys := make([]K, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -164,7 +164,7 @@ type errval struct {
 // Recursively process a region/Block until all the leaves (which are cells) have been traversed and processed
 func (director *Director) processSub(region interface{}, queryElem interface{}, wgPtr *sync.WaitGroup, cellCountPtr *int) (interface{}, error) {
 	var err error
-	keys := ExtractKeys(queryElem.(map[string]interface{}))
+	keys := getMapKeys(queryElem.(map[string]interface{}))
 	thisIsALeaf := false
 	for _, k := range keys {
 		if k == "controlQueryTemplate" {
@@ -313,7 +313,7 @@ func (director *Director) processSub(region interface{}, queryElem interface{}, 
 		// log.Printf("mysql_director processSub branch keys are %q", keys)
 		// this is a branch (not a leaf) so we keep traversing
 		// check to see if this is a statistic elem, so we can set the statisticType
-		var keys []string = ExtractKeys((region).(map[string]interface{}))
+		var keys []string = getMapKeys((region).(map[string]interface{}))
 		for _, elemKey := range keys {
 			for _, s := range director.statistics {
 				if elemKey == fmt.Sprint(s) {
@@ -336,7 +336,7 @@ func (director *Director) Run(region interface{}, queryMap map[string]interface{
 	// This is recursive. Recurse down to the cell levl then traverse back up processing
 	// all the cells on the way
 	// get all the statistic strings (they are the keys of the regionMap)
-	director.statistics = ExtractKeys((region).(map[string]interface{})) // declared at the top
+	director.statistics = getMapKeys((region).(map[string]interface{})) // declared at the top
 	// declare a waitgroup so that we can wait for all the stats to finish running
 	var wg sync.WaitGroup
 	// process the regionMap (all the values will be filled in)

--- a/pkg/director/mysql_director.go
+++ b/pkg/director/mysql_director.go
@@ -34,8 +34,6 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 )
 
-var dateRange DateRange
-
 const (
 	noTableFound   = "Error 1146 (42S02)"
 	convertingNull = "converting NULL"
@@ -50,10 +48,10 @@ func ExtractKeys[K comparable, V any](m map[K]V) []K {
 	return keys
 }
 
-func getMySqlConnection(mysqlCredentials DbCredentials) (*sql.DB, error) {
-	// get the connection
+// getMySQLConnection establishes a connection to the given SQL database
+// connection strings should be like: user:password@tcp(localhost:5555)
+func getMySQLConnection(mysqlCredentials DbCredentials) (*sql.DB, error) {
 	driver := "mysql"
-	//user:password@tcp(localhost:5555)
 	dataSource := fmt.Sprintf("%s:%s@tcp(%s)/", mysqlCredentials.User, mysqlCredentials.Password, mysqlCredentials.Host)
 	var db *sql.DB
 	db, err := sql.Open(driver, dataSource)
@@ -68,10 +66,10 @@ func getMySqlConnection(mysqlCredentials DbCredentials) (*sql.DB, error) {
 	return db, nil
 }
 
-var mysqlDirector = Director{}
-
-func NewMysqlDirector(mysqlCredentials DbCredentials, dateRange DateRange, minorThreshold float64, majorThreshold float64) (*Director, error) {
-	db, err := getMySqlConnection(mysqlCredentials)
+// newMySQLDirector creates a correctly initialized MySQL director. GetDirector should be used by clients instead of this.
+func newMySQLDirector(mysqlCredentials DbCredentials, dateRange DateRange, minorThreshold, majorThreshold float64) (*Director, error) {
+	mysqlDirector := Director{}
+	db, err := getMySQLConnection(mysqlCredentials)
 	if err != nil {
 		return nil, fmt.Errorf("mysql_director NewMysqlDirector error: %w", err)
 	} else {
@@ -86,9 +84,15 @@ func NewMysqlDirector(mysqlCredentials DbCredentials, dateRange DateRange, minor
 	return &mysqlDirector, nil
 }
 
-func queryDataPreCalc(stmnt string) (queryResult builder.PreCalcRecords, err error) {
+// Close cleans up the database connection and must be called
+func (director *Director) Close() error {
+	return director.db.Close()
+}
+
+// queryDataPreCalc extracts "preCalc" records from the database
+func (director *Director) queryDataPreCalc(stmnt string) (queryResult builder.PreCalcRecords, err error) {
 	var rows *sql.Rows
-	rows, err = mysqlDirector.db.Query(stmnt)
+	rows, err = director.db.Query(stmnt)
 	if err != nil {
 		err = fmt.Errorf("mysql_director queryData Query failed: %w", err)
 		return queryResult, err
@@ -107,9 +111,10 @@ func queryDataPreCalc(stmnt string) (queryResult builder.PreCalcRecords, err err
 	return queryResult, nil
 }
 
-func queryDataCTC(stmnt string) (queryResult builder.CTCRecords, err error) {
+// queryDataCTC extracts "CTC" records from the database
+func (director *Director) queryDataCTC(stmnt string) (queryResult builder.CTCRecords, err error) {
 	var rows *sql.Rows
-	rows, err = mysqlDirector.db.Query(stmnt)
+	rows, err = director.db.Query(stmnt)
 	if err != nil {
 		err = fmt.Errorf("mysql_director queryData Query failed: %w", err)
 		return queryResult, err
@@ -128,10 +133,10 @@ func queryDataCTC(stmnt string) (queryResult builder.CTCRecords, err error) {
 	return queryResult, nil
 }
 
-// func queryDataScalar(stmnt string, queryResult builder.ScalarRecords) (err error) {
-func queryDataScalar(stmnt string) (queryResult builder.ScalarRecords, err error) {
+// queryDataScalar extracts scalar records from the database
+func (director *Director) queryDataScalar(stmnt string) (queryResult builder.ScalarRecords, err error) {
 	var rows *sql.Rows
-	rows, err = mysqlDirector.db.Query(stmnt)
+	rows, err = director.db.Query(stmnt)
 	if err != nil {
 		err = fmt.Errorf("mysql_director queryData Query failed: %w", err)
 		return queryResult, err
@@ -150,12 +155,6 @@ func queryDataScalar(stmnt string) (queryResult builder.ScalarRecords, err error
 	return queryResult, nil
 }
 
-var (
-	statistics    []string
-	statisticType string
-	thisIsALeaf   bool
-)
-
 // used to return value and err from go routines
 type errval struct {
 	err error
@@ -163,10 +162,10 @@ type errval struct {
 }
 
 // Recursively process a region/Block until all the leaves (which are cells) have been traversed and processed
-func processSub(region interface{}, queryElem interface{}, wgPtr *sync.WaitGroup, cellCountPtr *int) (interface{}, error) {
+func (director *Director) processSub(region interface{}, queryElem interface{}, wgPtr *sync.WaitGroup, cellCountPtr *int) (interface{}, error) {
 	var err error
 	keys := ExtractKeys(queryElem.(map[string]interface{}))
-	thisIsALeaf = false
+	thisIsALeaf := false
 	for _, k := range keys {
 		if k == "controlQueryTemplate" {
 			thisIsALeaf = true
@@ -181,10 +180,10 @@ func processSub(region interface{}, queryElem interface{}, wgPtr *sync.WaitGroup
 		var ctlQueryStatement string = queryElem.(map[string]interface{})["controlQueryTemplate"].(string)
 		var expQueryStatement string = queryElem.(map[string]interface{})["experimentalQueryTemplate"].(string)
 		// substitute the {{fromSecs}} and {{toSecs}}
-		ctlQueryStatement = strings.Replace(ctlQueryStatement, "{{fromSecs}}", fmt.Sprint(dateRange.FromSecs), -1)
-		ctlQueryStatement = strings.Replace(ctlQueryStatement, "{{toSecs}}", fmt.Sprint(dateRange.ToSecs), -1)
-		expQueryStatement = strings.Replace(expQueryStatement, "{{fromSecs}}", fmt.Sprint(dateRange.FromSecs), -1)
-		expQueryStatement = strings.Replace(expQueryStatement, "{{toSecs}}", fmt.Sprint(dateRange.ToSecs), -1)
+		ctlQueryStatement = strings.Replace(ctlQueryStatement, "{{fromSecs}}", fmt.Sprint(director.dateRange.FromSecs), -1)
+		ctlQueryStatement = strings.Replace(ctlQueryStatement, "{{toSecs}}", fmt.Sprint(director.dateRange.ToSecs), -1)
+		expQueryStatement = strings.Replace(expQueryStatement, "{{fromSecs}}", fmt.Sprint(director.dateRange.FromSecs), -1)
+		expQueryStatement = strings.Replace(expQueryStatement, "{{toSecs}}", fmt.Sprint(director.dateRange.ToSecs), -1)
 		var err error
 		var queryResult interface{}
 		queryError := false
@@ -192,7 +191,7 @@ func processSub(region interface{}, queryElem interface{}, wgPtr *sync.WaitGroup
 		// what kind of data?
 		if strings.Contains(ctlQueryStatement, "hit") {
 			// get the data
-			ctlQueryResult, err := queryDataCTC(ctlQueryStatement)
+			ctlQueryResult, err := director.queryDataCTC(ctlQueryStatement)
 			if len(ctlQueryResult) == 0 && err == nil {
 				// no data is ok, but no need to go on either
 				return builder.ErrorValue, nil
@@ -203,7 +202,7 @@ func processSub(region interface{}, queryElem interface{}, wgPtr *sync.WaitGroup
 					log.Printf("mysql_director queryDataCTC ctlQueryStatement error %q", err)
 				}
 			} else {
-				expQueryResult, err := queryDataCTC(expQueryStatement)
+				expQueryResult, err := director.queryDataCTC(expQueryStatement)
 				if len(expQueryResult) == 0 && err == nil {
 					// no data is ok, but no need to go on either
 					return builder.ErrorValue, nil
@@ -220,7 +219,7 @@ func processSub(region interface{}, queryElem interface{}, wgPtr *sync.WaitGroup
 			}
 		} else if strings.Contains(ctlQueryStatement, "square_diff_sum") {
 			// get the data
-			ctlQueryResult, err := queryDataScalar(ctlQueryStatement)
+			ctlQueryResult, err := director.queryDataScalar(ctlQueryStatement)
 			if len(ctlQueryResult) == 0 && err == nil {
 				// no data is ok, but no need to go on either
 				return builder.ErrorValue, nil
@@ -232,7 +231,7 @@ func processSub(region interface{}, queryElem interface{}, wgPtr *sync.WaitGroup
 					log.Printf("mysql_director queryDataScalar ctlQueryStatement error %q", err)
 				}
 			} else {
-				expQueryResult, err := queryDataScalar(expQueryStatement)
+				expQueryResult, err := director.queryDataScalar(expQueryStatement)
 				if len(expQueryResult) == 0 && err == nil {
 					// no data is ok, but no need to go on either
 					return builder.ErrorValue, nil
@@ -249,7 +248,7 @@ func processSub(region interface{}, queryElem interface{}, wgPtr *sync.WaitGroup
 			}
 		} else if strings.Contains(ctlQueryStatement, "stat") {
 			// get the data
-			ctlQueryResult, err := queryDataPreCalc(ctlQueryStatement)
+			ctlQueryResult, err := director.queryDataPreCalc(ctlQueryStatement)
 			if len(ctlQueryResult) == 0 && err == nil {
 				// no data is ok, but no need to go on either
 				return builder.ErrorValue, nil
@@ -261,7 +260,7 @@ func processSub(region interface{}, queryElem interface{}, wgPtr *sync.WaitGroup
 					log.Printf("mysql_director queryDataPreCalc ctlQueryStatement error %q", err)
 				}
 			} else {
-				expQueryResult, err := queryDataPreCalc(expQueryStatement)
+				expQueryResult, err := director.queryDataPreCalc(expQueryStatement)
 				if len(expQueryResult) == 0 && err == nil {
 					// no data is ok, but no need to go on either
 					return builder.ErrorValue, nil
@@ -299,7 +298,7 @@ func processSub(region interface{}, queryElem interface{}, wgPtr *sync.WaitGroup
 				defer wgPtr.Done()
 				*cellCountPtr++
 				scc := builder.NewTwoSampleTTestBuilder()
-				value, err := (scc.Build(queryResult, statisticType, mysqlDirector.minorThreshold, mysqlDirector.majorThreshold))
+				value, err := (scc.Build(queryResult, director.statisticType, director.minorThreshold, director.majorThreshold))
 				c <- errval{err: err, val: value}
 			}()
 			ret := <-c
@@ -316,14 +315,14 @@ func processSub(region interface{}, queryElem interface{}, wgPtr *sync.WaitGroup
 		// check to see if this is a statistic elem, so we can set the statisticType
 		var keys []string = ExtractKeys((region).(map[string]interface{}))
 		for _, elemKey := range keys {
-			for _, s := range statistics {
+			for _, s := range director.statistics {
 				if elemKey == fmt.Sprint(s) {
-					statisticType = elemKey
+					director.statisticType = elemKey
 					break
 				}
 			}
 			queryElem := queryElem.(map[string]interface{})[elemKey]
-			region.(map[string]interface{})[elemKey], err = processSub(region.(map[string]interface{})[elemKey], queryElem, wgPtr, cellCountPtr)
+			region.(map[string]interface{})[elemKey], err = director.processSub(region.(map[string]interface{})[elemKey], queryElem, wgPtr, cellCountPtr)
 			if err != nil {
 				return builder.ErrorValue, err
 			}
@@ -337,12 +336,11 @@ func (director *Director) Run(region interface{}, queryMap map[string]interface{
 	// This is recursive. Recurse down to the cell levl then traverse back up processing
 	// all the cells on the way
 	// get all the statistic strings (they are the keys of the regionMap)
-	statistics = ExtractKeys((region).(map[string]interface{})) // declared at the top
-	dateRange = director.dateRange
+	director.statistics = ExtractKeys((region).(map[string]interface{})) // declared at the top
 	// declare a waitgroup so that we can wait for all the stats to finish running
 	var wg sync.WaitGroup
 	// process the regionMap (all the values will be filled in)
-	region, err := processSub(region, queryMap, &wg, cellCountPtr)
+	region, err := director.processSub(region, queryMap, &wg, cellCountPtr)
 	wg.Wait()
 	if err != nil {
 		return region, fmt.Errorf("mysql_director error in Run %w", err)

--- a/pkg/director/mysql_director.go
+++ b/pkg/director/mysql_director.go
@@ -41,7 +41,8 @@ const (
 	convertingNull = "converting NULL"
 )
 
-func Keys[K comparable, V any](m map[K]V) []K {
+// ExtractKeys returns a slice containing the keys in the given map
+func ExtractKeys[K comparable, V any](m map[K]V) []K {
 	keys := make([]K, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -164,7 +165,7 @@ type errval struct {
 // Recursively process a region/Block until all the leaves (which are cells) have been traversed and processed
 func processSub(region interface{}, queryElem interface{}, wgPtr *sync.WaitGroup, cellCountPtr *int) (interface{}, error) {
 	var err error
-	keys := Keys(queryElem.(map[string]interface{}))
+	keys := ExtractKeys(queryElem.(map[string]interface{}))
 	thisIsALeaf = false
 	for _, k := range keys {
 		if k == "controlQueryTemplate" {
@@ -313,7 +314,7 @@ func processSub(region interface{}, queryElem interface{}, wgPtr *sync.WaitGroup
 		// log.Printf("mysql_director processSub branch keys are %q", keys)
 		// this is a branch (not a leaf) so we keep traversing
 		// check to see if this is a statistic elem, so we can set the statisticType
-		var keys []string = Keys((region).(map[string]interface{}))
+		var keys []string = ExtractKeys((region).(map[string]interface{}))
 		for _, elemKey := range keys {
 			for _, s := range statistics {
 				if elemKey == fmt.Sprint(s) {
@@ -336,7 +337,7 @@ func (director *Director) Run(region interface{}, queryMap map[string]interface{
 	// This is recursive. Recurse down to the cell levl then traverse back up processing
 	// all the cells on the way
 	// get all the statistic strings (they are the keys of the regionMap)
-	statistics = Keys((region).(map[string]interface{})) // declared at the top
+	statistics = ExtractKeys((region).(map[string]interface{})) // declared at the top
 	dateRange = director.dateRange
 	// declare a waitgroup so that we can wait for all the stats to finish running
 	var wg sync.WaitGroup

--- a/pkg/director/mysql_director_integration_test.go
+++ b/pkg/director/mysql_director_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/NOAA-GSL/vxDataProcessor/pkg/builder"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/joho/godotenv"
+	"go.uber.org/goleak"
 )
 
 func loadEnvironmentFile() {
@@ -32,6 +33,7 @@ func loadEnvironmentFile() {
 }
 
 func Test_getMySqlConnection(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	type args struct {
 		mysqlCredentials DbCredentials
 	}
@@ -80,6 +82,7 @@ func Test_getMySqlConnection(t *testing.T) {
 
 // record.squareDiffSum record.NSum record.obsModelDiffSum record.modelSum record.obsSum record.absSum record.time
 func Test_mySqlQuery(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	loadEnvironmentFile()
 	var mysqlCredentials DbCredentials
 	// refer to https://github.com/go-sql-driver/mysql/#dsn-data-source-name

--- a/pkg/director/mysql_director_integration_test.go
+++ b/pkg/director/mysql_director_integration_test.go
@@ -67,7 +67,7 @@ func Test_getMySqlConnection(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getMySqlConnection(tt.args.mysqlCredentials)
+			got, err := getMySQLConnection(tt.args.mysqlCredentials)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getMySqlConnection() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -98,7 +98,7 @@ func Test_mySqlQuery(t *testing.T) {
 	if mysqlCredentials.Password == "" {
 		t.Fatalf("Undefined MYSQL_PASSWORD in environment")
 	}
-	mysqlDB, err := getMySqlConnection(mysqlCredentials)
+	mysqlDB, err := getMySQLConnection(mysqlCredentials)
 	if err != nil {
 		t.Fatalf("getMySqlConnection() error = %v", err)
 		return
@@ -150,8 +150,8 @@ func Test_mySqlQuery(t *testing.T) {
 		}
 
 		stmnt := string(buf)
-		fromEpoch := tt.fromEpoch // Tue, 1 Feb 2023 20:00:00 GMT
-		toEpoch := tt.toEpoch     // Tue, 1 Mar 2023 20:00:00 GMT
+		fromEpoch := tt.fromEpoch
+		toEpoch := tt.toEpoch
 		stmnt = strings.ReplaceAll(stmnt, "{ { fromSecs } }", fromEpoch)
 		stmnt = strings.ReplaceAll(stmnt, "{ { toSecs } }", toEpoch)
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/manager/iManager.go
+++ b/pkg/manager/iManager.go
@@ -39,10 +39,13 @@ type Manager struct {
 
 type ManagerBuilder interface {
 	Run() error
+	Close() error
 	SetStatus(status string)
 	SetProcessedAt() error
 }
 
+// Returns a Manager based on the document type. Make sure to call Close() on
+// the returned manager to clean up database connections.
 func GetManager(documentID string) (*Manager, error) {
 	documentType := strings.Split(documentID, ":")[0]
 	if documentType == "SC" {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -58,6 +58,15 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// getMapKeys returns an unsorted slice containing the keys in the given map
+func getMapKeys[K comparable, V any](m map[K]V) []K {
+	keys := make([]K, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 // loadEnvironment retrieves required settings from the environment
 func loadEnvironment() (mysqlCredentials, cbCredentials director.DbCredentials, err error) {
 	cbCredentials = director.DbCredentials{
@@ -370,7 +379,7 @@ func (mngr *Manager) Run() (err error) {
 		_ = mngr.SetStatus("error")
 		return fmt.Errorf("manager Run error getting resultsBlocks: %w", err)
 	}
-	blockKeys := director.ExtractKeys(resultsBlocks)
+	blockKeys := getMapKeys(resultsBlocks)
 	sort.Strings(blockKeys)
 	// get the appUrl from the first block - they should all be the same
 	scorecardAppUrl := resultsBlocks[blockKeys[0]].(map[string]interface{})["blockApplication"].(string)
@@ -428,9 +437,9 @@ func (mngr *Manager) Run() (err error) {
 			}
 		}
 		queryData := queryBlock["data"].(map[string]interface{})
-		blockRegionNames := director.ExtractKeys(block.(map[string]interface{})["data"].(map[string]interface{}))
+		blockRegionNames := getMapKeys(block.(map[string]interface{})["data"].(map[string]interface{}))
 		sort.Strings(blockRegionNames)
-		queryRegionNames := director.ExtractKeys(queryData)
+		queryRegionNames := getMapKeys(queryData)
 		sort.Strings(queryRegionNames)
 		numBlockRegions := len(blockRegionNames)
 		numQueryRegions := len(queryRegionNames)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -355,7 +355,7 @@ func (mngr Manager) Run() (err error) {
 		_ = mngr.SetStatus("error")
 		return fmt.Errorf("manager Run error getting resultsBlocks: %w", err)
 	}
-	blockKeys := director.Keys(resultsBlocks)
+	blockKeys := director.ExtractKeys(resultsBlocks)
 	sort.Strings(blockKeys)
 	// get the appUrl from the first block - they should all be the same
 	scorecardAppUrl := resultsBlocks[blockKeys[0]].(map[string]interface{})["blockApplication"].(string)
@@ -413,9 +413,9 @@ func (mngr Manager) Run() (err error) {
 			}
 		}
 		queryData := queryBlock["data"].(map[string]interface{})
-		blockRegionNames := director.Keys(block.(map[string]interface{})["data"].(map[string]interface{}))
+		blockRegionNames := director.ExtractKeys(block.(map[string]interface{})["data"].(map[string]interface{}))
 		sort.Strings(blockRegionNames)
-		queryRegionNames := director.Keys(queryData)
+		queryRegionNames := director.ExtractKeys(queryData)
 		sort.Strings(queryRegionNames)
 		numBlockRegions := len(blockRegionNames)
 		numQueryRegions := len(queryRegionNames)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -98,6 +98,12 @@ func loadEnvironment() (mysqlCredentials, cbCredentials director.DbCredentials, 
 	return mysqlCredentials, cbCredentials, nil
 }
 
+// Close is required after we are finished with a Manager. It usually recommended to
+// call it with defer.
+func (mngr *Manager) Close() error {
+	return mngr.cb.Cluster.Close(nil)
+}
+
 // get the couchbase connection
 // mysql connections are maintained in the mysql_director
 func getConnection(mngr *Manager, cbCredentials director.DbCredentials) (err error) {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -105,9 +105,9 @@ func (mngr *Manager) Close() error {
 	return mngr.cb.Cluster.Close(nil)
 }
 
-// getConnection establishes the couchbase connection
+// getCouchbaseConnection establishes the couchbase connection
 // mysql connections are maintained in the mysql_director
-func (mngr *Manager) getConnection(cbCredentials director.DbCredentials) (err error) { // TODO - rename to getCouchbaseConnection to standardize with director.getMySQLConnection
+func (mngr *Manager) getCouchbaseConnection(cbCredentials director.DbCredentials) (err error) {
 	options := gocb.ClusterOptions{
 		Authenticator: gocb.PasswordAuthenticator{
 			Username: cbCredentials.User,
@@ -360,7 +360,7 @@ func (mngr *Manager) Run() (err error) {
 	if err != nil {
 		return fmt.Errorf("manager loadEnvironmant error %w", err)
 	}
-	err = mngr.getConnection(cbCredentials)
+	err = mngr.getCouchbaseConnection(cbCredentials)
 	if err != nil {
 		return fmt.Errorf("manager Run GetConnection error: %w", err)
 	}

--- a/pkg/manager/manager_integration_test.go
+++ b/pkg/manager/manager_integration_test.go
@@ -351,7 +351,7 @@ func Test_runManager(t *testing.T) {
 			name:            "test_Anomaly_Correlation",
 			docId:           "SCTEST:test_Anomaly_Correlation",
 			fileName:        "./testdata/test_Anomaly_Correlation.json",
-			expectedSeconds: 5,
+			expectedSeconds: 20,
 		},
 		{
 			name:            "test_Ceiling",
@@ -405,7 +405,7 @@ func Test_runManager(t *testing.T) {
 			name:            "test_Surface_Land_Use",
 			docId:           "SCTEST:test_Surface_Land_Use",
 			fileName:        "./testdata/test_Surface_Land_Use.json",
-			expectedSeconds: 40,
+			expectedSeconds: 50,
 		},
 		{
 			name:            "test_Vertically_Integrated_Liquid",

--- a/pkg/manager/manager_integration_test.go
+++ b/pkg/manager/manager_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/NOAA-GSL/vxDataProcessor/pkg/director"
 	"github.com/couchbase/gocb/v2"
 	"github.com/joho/godotenv"
+	"go.uber.org/goleak"
 )
 
 func loadEnvironmentFile() {
@@ -72,6 +73,7 @@ func upsertTestDoc(mngr *Manager, test_doc_file string, test_doc_id string) erro
 }
 
 func TestDirector_test_connection(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	var cbCredentials director.DbCredentials
 	var mysqlCredentials director.DbCredentials
 	var err error
@@ -110,6 +112,7 @@ func TestDirector_test_connection(t *testing.T) {
 }
 
 func Test_loadEnvironment(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	tests := []struct {
 		name                 string
 		wantMysqlCredentials director.DbCredentials
@@ -180,6 +183,7 @@ func Test_loadEnvironment(t *testing.T) {
 }
 
 func Test_getQueryBlocks(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	// setup a test document
 	documentID := "SCTEST:test_scorecard"
 	t.Setenv("PROC_TESTING_ACCEPT_SCTEST_DOCIDS", "")
@@ -228,7 +232,7 @@ func Test_getQueryBlocks(t *testing.T) {
 			if retData == nil {
 				t.Errorf("%v error = %v", tt.name, err)
 			}
-			got := director.Keys(retData)
+			got := director.ExtractKeys(retData)
 			sort.Strings(got)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getQueryBlocks() error = %v, wantErr %v", err, tt.wantErr)
@@ -242,6 +246,7 @@ func Test_getQueryBlocks(t *testing.T) {
 }
 
 func Test_getSliceResultBlocks(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	// setup a test document
 	documentID := "SCTEST:test_scorecard"
 	t.Setenv("PROC_TESTING_ACCEPT_SCTEST_DOCIDS", "")
@@ -290,7 +295,7 @@ func Test_getSliceResultBlocks(t *testing.T) {
 			if retData == nil {
 				t.Errorf("%v error = %v", tt.name, err)
 			}
-			got := director.Keys(retData[0])
+			got := director.ExtractKeys(retData[0])
 			sort.Strings(got)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getPlotParamCurves() error = %v, wantErr %v", err, tt.wantErr)
@@ -304,6 +309,7 @@ func Test_getSliceResultBlocks(t *testing.T) {
 }
 
 func Test_runManager(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	t.Setenv("PROC_TESTING_ACCEPT_SCTEST_DOCIDS", "")
 	var mngr *Manager
 	var err error

--- a/pkg/manager/manager_integration_test.go
+++ b/pkg/manager/manager_integration_test.go
@@ -94,7 +94,7 @@ func TestDirector_test_connection(t *testing.T) {
 	t.Setenv("PROC_TESTING_ACCEPT_SCTEST_DOCIDS", "")
 	mngr, _ := GetManager(documentID)
 	defer mngr.Close()
-	err = mngr.getConnection(cbCredentials)
+	err = mngr.getCouchbaseConnection(cbCredentials)
 	if err != nil {
 		t.Fatal(fmt.Sprint("TestDirector_test_connection Build GetConnection error ", err))
 	}
@@ -206,7 +206,7 @@ func Test_getQueryBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatal(fmt.Errorf("manager loadEnvironment error loadEnvironment %w", err))
 	}
-	err = mngr.getConnection(cbCredentials)
+	err = mngr.getCouchbaseConnection(cbCredentials)
 	if err != nil {
 		t.Fatal(fmt.Errorf("manager loadEnvironment error getConnection %w", err))
 	}
@@ -275,7 +275,7 @@ func Test_getSliceResultBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatal(fmt.Errorf("manager loadEnvironment error loadEnvironment %w", err))
 	}
-	err = mngr.getConnection(cbCredentials)
+	err = mngr.getCouchbaseConnection(cbCredentials)
 	if err != nil {
 		t.Fatal(fmt.Errorf("manager loadEnvironment error getConnection %w", err))
 	}
@@ -450,7 +450,7 @@ func Test_runManager(t *testing.T) {
 		if err != nil {
 			t.Fatal(fmt.Errorf("manager - getManager for %s error  %w", tt.name, err))
 		}
-		err = setupManager.getConnection(cbCredentials)
+		err = setupManager.getCouchbaseConnection(cbCredentials)
 		if err != nil {
 			t.Fatal(fmt.Errorf("manager loadEnvironmenttest %s error getConnection %w", tt.name, err))
 		}

--- a/pkg/manager/manager_integration_test.go
+++ b/pkg/manager/manager_integration_test.go
@@ -192,7 +192,12 @@ func Test_getQueryBlocks(t *testing.T) {
 	var err error
 	loadEnvironmentFile()
 	mngr, err = GetManager(documentID)
-	defer mngr.Close()
+	defer func() {
+		errd := mngr.Close()
+		if errd != nil {
+			log.Printf("Error cleaning up manager: %q", errd)
+		}
+	}()
 	if err != nil {
 		t.Fatal(fmt.Errorf("manager loadEnvironment error GetManager %w", err))
 	}
@@ -256,7 +261,12 @@ func Test_getSliceResultBlocks(t *testing.T) {
 	var err error
 	loadEnvironmentFile()
 	mngr, err = GetManager(documentID)
-	defer mngr.Close()
+	defer func() {
+		errd := mngr.Close()
+		if errd != nil {
+			log.Printf("Error cleaning up manager: %q", errd)
+		}
+	}()
 	if err != nil {
 		t.Fatal(fmt.Errorf("manager loadEnvironment error GetManager %w", err))
 	}

--- a/pkg/manager/manager_integration_test.go
+++ b/pkg/manager/manager_integration_test.go
@@ -94,7 +94,7 @@ func TestDirector_test_connection(t *testing.T) {
 	t.Setenv("PROC_TESTING_ACCEPT_SCTEST_DOCIDS", "")
 	mngr, _ := GetManager(documentID)
 	defer mngr.Close()
-	err = getConnection(mngr, cbCredentials)
+	err = mngr.getConnection(cbCredentials)
 	if err != nil {
 		t.Fatal(fmt.Sprint("TestDirector_test_connection Build GetConnection error ", err))
 	}
@@ -201,7 +201,7 @@ func Test_getQueryBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatal(fmt.Errorf("manager loadEnvironment error loadEnvironment %w", err))
 	}
-	err = getConnection(mngr, cbCredentials)
+	err = mngr.getConnection(cbCredentials)
 	if err != nil {
 		t.Fatal(fmt.Errorf("manager loadEnvironment error getConnection %w", err))
 	}
@@ -230,7 +230,7 @@ func Test_getQueryBlocks(t *testing.T) {
 		var retData map[string]interface{}
 		var err error
 		t.Run(tt.name, func(t *testing.T) {
-			retData, err = getQueryBlocks(*tt.args)
+			retData, err = tt.args.getQueryBlocks()
 			if retData == nil {
 				t.Errorf("%v error = %v", tt.name, err)
 			}
@@ -265,7 +265,7 @@ func Test_getSliceResultBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatal(fmt.Errorf("manager loadEnvironment error loadEnvironment %w", err))
 	}
-	err = getConnection(mngr, cbCredentials)
+	err = mngr.getConnection(cbCredentials)
 	if err != nil {
 		t.Fatal(fmt.Errorf("manager loadEnvironment error getConnection %w", err))
 	}
@@ -294,7 +294,7 @@ func Test_getSliceResultBlocks(t *testing.T) {
 		var retData []map[string]interface{}
 		var err error
 		t.Run(tt.name, func(t *testing.T) {
-			retData, err = getPlotParamCurves(*tt.args)
+			retData, err = tt.args.getPlotParamCurves()
 			if retData == nil {
 				t.Errorf("%v error = %v", tt.name, err)
 			}
@@ -314,7 +314,7 @@ func Test_getSliceResultBlocks(t *testing.T) {
 func Test_runManager(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	t.Setenv("PROC_TESTING_ACCEPT_SCTEST_DOCIDS", "")
-	var setupConnection *Manager
+	var setupManager *Manager
 	var err error
 	loadEnvironmentFile()
 	tests := []struct {
@@ -436,19 +436,19 @@ func Test_runManager(t *testing.T) {
 		log.Printf("Starting test %s", tt.name)
 		start := time.Now()
 		// Test setup
-		setupConnection, err = GetManager(tt.docId)
+		setupManager, err = GetManager(tt.docId)
 		if err != nil {
 			t.Fatal(fmt.Errorf("manager - getManager for %s error  %w", tt.name, err))
 		}
-		err = getConnection(setupConnection, cbCredentials)
+		err = setupManager.getConnection(cbCredentials)
 		if err != nil {
 			t.Fatal(fmt.Errorf("manager loadEnvironmenttest %s error getConnection %w", tt.name, err))
 		}
-		err = upsertTestDoc(setupConnection, tt.fileName, tt.docId)
+		err = upsertTestDoc(setupManager, tt.fileName, tt.docId)
 		if err != nil {
 			t.Fatal(fmt.Errorf("manager upsertTestDoc test %s error upserting test scorecard %w", tt.name, err))
 		}
-		setupConnection.Close() // Can't defer since we're in a for loop
+		setupManager.Close() // Can't defer since we're in a for loop
 
 		// Test execution
 		manager, err := GetManager(tt.docId)

--- a/pkg/manager/manager_integration_test.go
+++ b/pkg/manager/manager_integration_test.go
@@ -239,7 +239,7 @@ func Test_getQueryBlocks(t *testing.T) {
 			if retData == nil {
 				t.Errorf("%v error = %v", tt.name, err)
 			}
-			got := director.ExtractKeys(retData)
+			got := getMapKeys(retData)
 			sort.Strings(got)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getQueryBlocks() error = %v, wantErr %v", err, tt.wantErr)
@@ -308,7 +308,7 @@ func Test_getSliceResultBlocks(t *testing.T) {
 			if retData == nil {
 				t.Errorf("%v error = %v", tt.name, err)
 			}
-			got := director.ExtractKeys(retData[0])
+			got := getMapKeys(retData[0])
 			sort.Strings(got)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getPlotParamCurves() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
This merge introduces a number of changes and refactorings
- Add goleak to our integration test suite to check for leaking goroutines.
- Refactor the `director.ExtractKeys` function to `getMapKeys` for clarity
- Refactor the `manager` to eliminate global variables and to make standalone functions full struct members
- Refactor the `director` to eliminate global variables and to make standalone functions full struct members
- Add a `.Close()` cleanup member function to the `manager` and `director` that closes out database connections
- Add a call to clean up idle HTTP connections in the client pkg

This has the effect of dropping the number of dangling goroutines from the 100's to zero in most cases. However, there is one occasional flaky goroutine that appears with the `client` package. We'll want to address that in the future so our test suite doesn't have test flakes. 